### PR TITLE
Release 1.9.8

### DIFF
--- a/.azure-pipelines/ci-build.yml
+++ b/.azure-pipelines/ci-build.yml
@@ -256,7 +256,9 @@ extends:
                     tag: 'v$(VERSION_STRING)'
                     title: '$(VERSION_STRING)'
                     releaseNotesSource: inline
-                    assets: '!**/**'
+                    assets: |
+                      !**/**
+                      $(Pipeline.Workspace)/Microsoft.Kiota.*.*nupkg
                     changeLogType: issueBased
                     isPreRelease : '$(IS_PRE_RELEASE)'
                     addChangeLog : true 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
   <!-- Common default project properties for ALL projects-->
   <PropertyGroup>
     <VersionPrefix>1.9.8</VersionPrefix>
-    <VersionSuffix>preview</VersionSuffix>
+    <VersionSuffix></VersionSuffix>
     <!-- This is overidden in test projects by setting to true-->
     <IsTestProject>false</IsTestProject>
     <!-- This is overidden in test projects by setting to true-->


### PR DESCRIPTION
Closes https://github.com/microsoft/kiota-dotnet/issues/238

Publishes new release of Kiota libraries with all versions aligned after validation of preview releases. 