### PR TITLE
Aligns Enum serialization across packages and pass relevant JsonWriterOptions from the KiotaJsonSerializationContext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.10.1] - 2024-08-01
 
 - Cleans up enum serialization to read from attributes for form and text serialization [#284](https://github.com/microsoft/kiota-dotnet/issues/284)
+- Pass relevant `JsonWriterOptions` from the `KiotaJsonSerializationContext.Options` to the `Utf8JsonWriter` when writing json to enable customization. [#281](https://github.com/microsoft/kiota-dotnet/issues/281)
 
 ## [1.10.0] - 2024-07-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.10.1] - 2024-08-01
+
+- Cleans up enum serialization to read from attributes for form and text serialization [#284](https://github.com/microsoft/kiota-dotnet/issues/284)
+
 ## [1.10.0] - 2024-07-17
 
 - Adds Kiota bundle package to provide default adapter with registrations setup. [#290](https://github.com/microsoft/kiota-dotnet/issues/290)

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <!-- Common default project properties for ALL projects-->
   <PropertyGroup>
-    <VersionPrefix>1.10.0</VersionPrefix>
+    <VersionPrefix>1.10.1</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <!-- This is overidden in test projects by setting to true-->
     <IsTestProject>false</IsTestProject>

--- a/src/abstractions/Helpers/EnumHelpers.cs
+++ b/src/abstractions/Helpers/EnumHelpers.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Reflection;
 using System.Runtime.Serialization;
+using Microsoft.Kiota.Abstractions.Extensions;
 
 #if NET5_0_OR_GREATER
 using System.Diagnostics.CodeAnalysis;
@@ -153,6 +154,30 @@ namespace Microsoft.Kiota.Abstractions.Helpers
                 }
             }
             return false;
+        }
+
+        /// <summary>
+        /// Gets the enum string representation of the given value. Looks up if there is an <see cref="EnumMemberAttribute"/> and returns the value if found, otherwise returns the enum name in camel case.
+        /// </summary>
+        /// <typeparam name="T">The Enum type</typeparam>
+        /// <param name="value">The enum value</param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentException">If value is null</exception>
+#if NET5_0_OR_GREATER
+        public static string? GetEnumStringValue<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] T>(T value) where T : struct, Enum
+#else
+        public static string? GetEnumStringValue<T>(T value) where T : struct, Enum
+#endif
+        {
+            var type = typeof(T);
+
+            if(Enum.GetName(type, value) is not { } name)
+                throw new ArgumentException($"Invalid Enum value {value} for enum of type {type}");
+
+            if(type.GetField(name)?.GetCustomAttribute<EnumMemberAttribute>() is { } attribute)
+                return attribute.Value;
+
+            return name.ToFirstCharacterLowerCase();
         }
     }
 }

--- a/src/serialization/form/FormSerializationWriter.cs
+++ b/src/serialization/form/FormSerializationWriter.cs
@@ -11,6 +11,7 @@ using System.Diagnostics.CodeAnalysis;
 #endif
 using System;
 using System.Collections.Generic;
+using Microsoft.Kiota.Abstractions.Helpers;
 
 namespace Microsoft.Kiota.Serialization.Form;
 /// <summary>Represents a serialization writer that can be used to write a form url encoded string.</summary>
@@ -247,13 +248,13 @@ public class FormSerializationWriter : ISerializationWriter
         StringBuilder? valueNames = null;
         foreach(var x in values)
         {
-            if(x.HasValue && Enum.GetName(typeof(T), x.Value) is string valueName)
+            if(x.HasValue && EnumHelpers.GetEnumStringValue(x.Value) is string valueName)
             {
                 if(valueNames == null)
                     valueNames = new StringBuilder();
                 else
                     valueNames.Append(",");
-                valueNames.Append(valueName.ToFirstCharacterLowerCase());
+                valueNames.Append(valueName);
             }
         }
 
@@ -281,16 +282,16 @@ public class FormSerializationWriter : ISerializationWriter
                 StringBuilder valueNames = new StringBuilder();
                 foreach(var x in values)
                 {
-                    if(value.Value.HasFlag(x) && Enum.GetName(typeof(T), x) is string valueName)
+                    if(value.Value.HasFlag(x) && EnumHelpers.GetEnumStringValue(x) is string valueName)
                     {
                         if(valueNames.Length > 0)
                             valueNames.Append(",");
-                        valueNames.Append(valueName.ToFirstCharacterLowerCase());
+                        valueNames.Append(valueName);
                     }
                 }
                 WriteStringValue(key, valueNames.ToString());
             }
-            else WriteStringValue(key, value.Value.ToString().ToFirstCharacterLowerCase());
+            else WriteStringValue(key, EnumHelpers.GetEnumStringValue(value.Value));
         }
     }
 }

--- a/src/serialization/json/JsonSerializationWriter.cs
+++ b/src/serialization/json/JsonSerializationWriter.cs
@@ -48,7 +48,11 @@ namespace Microsoft.Kiota.Serialization.Json
         public JsonSerializationWriter(KiotaJsonSerializationContext kiotaJsonSerializationContext)
         {
             _kiotaJsonSerializationContext = kiotaJsonSerializationContext;
-            writer = new Utf8JsonWriter(_stream);
+            writer = new Utf8JsonWriter(_stream, new JsonWriterOptions
+            {
+                Encoder = kiotaJsonSerializationContext.Options.Encoder,
+                Indented = kiotaJsonSerializationContext.Options.WriteIndented
+            });
         }
 
         /// <summary>

--- a/src/serialization/json/JsonSerializationWriter.cs
+++ b/src/serialization/json/JsonSerializationWriter.cs
@@ -7,12 +7,11 @@ using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
-using System.Runtime.Serialization;
 using System.Text;
 using System.Text.Json;
 using System.Xml;
 using Microsoft.Kiota.Abstractions;
-using Microsoft.Kiota.Abstractions.Extensions;
+using Microsoft.Kiota.Abstractions.Helpers;
 using Microsoft.Kiota.Abstractions.Serialization;
 
 #if NET5_0_OR_GREATER
@@ -290,7 +289,7 @@ namespace Microsoft.Kiota.Serialization.Json
                     StringBuilder valueNames = new StringBuilder();
                     foreach(var x in values)
                     {
-                        if(value.Value.HasFlag(x) && GetEnumName(x) is string valueName)
+                        if(value.Value.HasFlag(x) && EnumHelpers.GetEnumStringValue(x) is string valueName)
                         {
                             if(valueNames.Length > 0)
                                 valueNames.Append(",");
@@ -299,7 +298,7 @@ namespace Microsoft.Kiota.Serialization.Json
                     }
                     WriteStringValue(null, valueNames.ToString());
                 }
-                else WriteStringValue(null, GetEnumName(value.Value));
+                else WriteStringValue(null, EnumHelpers.GetEnumStringValue(value.Value));
             }
         }
 
@@ -559,22 +558,7 @@ namespace Microsoft.Kiota.Serialization.Json
             writer.Dispose();
             GC.SuppressFinalize(this);
         }
-#if NET5_0_OR_GREATER
-        private static string? GetEnumName<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] T>(T value) where T : struct, Enum
-#else
-        private static string? GetEnumName<T>(T value) where T : struct, Enum
-#endif
-        {
-            var type = typeof(T);
 
-            if(Enum.GetName(type, value) is not { } name)
-                throw new ArgumentException($"Invalid Enum value {value} for enum of type {type}");
-
-            if(type.GetField(name)?.GetCustomAttribute<EnumMemberAttribute>() is { } attribute)
-                return attribute.Value;
-
-            return name.ToFirstCharacterLowerCase();
-        }
         /// <summary>
         /// Writes a untyped value for the specified key.
         /// </summary>

--- a/src/serialization/text/TextSerializationWriter.cs
+++ b/src/serialization/text/TextSerializationWriter.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Xml;
 using Microsoft.Kiota.Abstractions;
 using Microsoft.Kiota.Abstractions.Extensions;
+using Microsoft.Kiota.Abstractions.Helpers;
 using Microsoft.Kiota.Abstractions.Serialization;
 
 #if NET5_0_OR_GREATER
@@ -118,5 +119,5 @@ public class TextSerializationWriter : ISerializationWriter, IDisposable
 #else
     public void WriteEnumValue<T>(string? key, T? value) where T : struct, Enum
 #endif
-    => WriteStringValue(key, value.HasValue ? value.Value.ToString().ToFirstCharacterLowerCase() : null);
+    => WriteStringValue(key, value.HasValue ? EnumHelpers.GetEnumStringValue(value.Value) : null);
 }

--- a/tests/serialization/form/FormSerializationWriterTests.cs
+++ b/tests/serialization/form/FormSerializationWriterTests.cs
@@ -436,6 +436,24 @@ public class FormSerializationWriterTests
     }
 
     [Fact]
+    public void WriteEnumValueWithAttribute_IsWrittenCorrectly()
+    {
+        // Arrange
+        var value = TestNamingEnum.Item2SubItem1;
+
+        using var formSerializationWriter = new FormSerializationWriter();
+
+        // Act
+        formSerializationWriter.WriteEnumValue<TestNamingEnum>("prop1", value);
+        var contentStream = formSerializationWriter.GetSerializedContent();
+        using var reader = new StreamReader(contentStream, Encoding.UTF8);
+        var serializedString = reader.ReadToEnd();
+
+        // Assert
+        Assert.Equal("prop1=Item2%3ASubItem1", serializedString);
+    }
+
+    [Fact]
     public void WriteCollectionOfEnumValues_IsWrittenCorrectly()
     {
         // Arrange

--- a/tests/serialization/form/Mocks/TestNamingEnum.cs
+++ b/tests/serialization/form/Mocks/TestNamingEnum.cs
@@ -1,0 +1,13 @@
+﻿using System.Runtime.Serialization;
+
+namespace Microsoft.Kiota.Serialization.Form.Tests.Mocks
+{
+    public enum TestNamingEnum
+    {
+        Item1,
+        [EnumMember(Value = "Item2:SubItem1")]
+        Item2SubItem1,
+        [EnumMember(Value = "Item3:SubItem1")]
+        Item3SubItem1
+    }
+}

--- a/tests/serialization/text/Mocks/TestEnum.cs
+++ b/tests/serialization/text/Mocks/TestEnum.cs
@@ -1,12 +1,8 @@
-﻿using System.Runtime.Serialization;
-
-namespace Microsoft.Kiota.Serialization.Text.Tests.Mocks
+﻿namespace Microsoft.Kiota.Serialization.Text.Tests.Mocks
 {
     public enum TestEnum
     {
-        [EnumMember(Value = "Value_1")]
         FirstItem,
-        [EnumMember(Value = "Value_2")]
         SecondItem,
     }
 }

--- a/tests/serialization/text/Mocks/TestNamingEnum.cs
+++ b/tests/serialization/text/Mocks/TestNamingEnum.cs
@@ -1,0 +1,13 @@
+﻿using System.Runtime.Serialization;
+
+namespace Microsoft.Kiota.Serialization.Text.Tests.Mocks
+{
+    public enum TestNamingEnum
+    {
+        Item1,
+        [EnumMember(Value = "Item2:SubItem1")]
+        Item2SubItem1,
+        [EnumMember(Value = "Item3:SubItem1")]
+        Item3SubItem1
+    }
+}

--- a/tests/serialization/text/TextParseNodeTests.cs
+++ b/tests/serialization/text/TextParseNodeTests.cs
@@ -41,12 +41,12 @@ namespace Microsoft.Kiota.Serialization.Text.Tests
         [Fact]
         public void TextParseNode_GetEnumFromEnumMember()
         {
-            var text = "Value_2";
+            var text = "Item2:SubItem1";
             var parseNode = new TextParseNode(text);
 
-            var result = parseNode.GetEnumValue<TestEnum>();
+            var result = parseNode.GetEnumValue<TestNamingEnum>();
 
-            Assert.Equal(TestEnum.SecondItem, result);
+            Assert.Equal(TestNamingEnum.Item2SubItem1, result);
         }
 
         [Fact]

--- a/tests/serialization/text/TextSerializationWriterTests.cs
+++ b/tests/serialization/text/TextSerializationWriterTests.cs
@@ -353,6 +353,25 @@ namespace Microsoft.Kiota.Serialization.Text.Tests
             Assert.Equal("firstItem", serializedString);
         }
 
+
+        [Fact]
+        public void WriteEnumValueWithAttribute_IsWrittenCorrectly()
+        {
+            // Arrange
+            var value = TestNamingEnum.Item2SubItem1;
+
+            using var formSerializationWriter = new TextSerializationWriter();
+
+            // Act
+            formSerializationWriter.WriteEnumValue<TestNamingEnum>(null, value);
+            var contentStream = formSerializationWriter.GetSerializedContent();
+            using var reader = new StreamReader(contentStream, Encoding.UTF8);
+            var serializedString = reader.ReadToEnd();
+
+            // Assert
+            Assert.Equal("Item2:SubItem1", serializedString);
+        }
+
         [Fact]
         public void WriteCollectionOfEnumValues_ThrowsInvalidOperationException()
         {


### PR DESCRIPTION
Fixes https://github.com/microsoft/kiota-dotnet/issues/281
Fixes https://github.com/microsoft/kiota-dotnet/issues/284

This PR 
- Cleans up enum serialization to read from attributes for form and text serialization. This uses the shared helper to provide consistent results. Tests updated.
- Pass relevant `JsonWriterOptions` from the `KiotaJsonSerializationContext.Options` to the `Utf8JsonWriter` when writing json to enable customization for the writer.