### PR TITLE
The call to ApiClientBuilder.EnableBackingStoreForParseNodeFactory wo…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.12.2] - 2024-08-23
+
+### Changed
+
+- Fixed a bug where calls to ApiClientBuilder.EnableBackingStoreForParseNodeFactory and ApiClientBuilder.EnableBackingStoreForSerializationWriterFactory would enable a BackingStore around BackingStores. [#2563] (https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/2563) [#2588] (https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/2588)
+
 ## [1.12.1] - 2024-08-21
 
 ### Changed

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <!-- Common default project properties for ALL projects-->
   <PropertyGroup>
-    <VersionPrefix>1.12.1</VersionPrefix>
+    <VersionPrefix>1.12.2</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <!-- This is overidden in test projects by setting to true-->
     <IsTestProject>false</IsTestProject>

--- a/src/abstractions/ApiClientBuilder.cs
+++ b/src/abstractions/ApiClientBuilder.cs
@@ -50,6 +50,9 @@ namespace Microsoft.Kiota.Abstractions
                 if(registry != SerializationWriterFactoryRegistry.DefaultInstance)// if the registry is the default instance, we already enabled it above. No need to do it twice
                     EnableBackingStoreForSerializationRegistry(SerializationWriterFactoryRegistry.DefaultInstance);
             }
+            if(result is BackingStoreSerializationWriterProxyFactory)
+                //We are already enabled so use it.
+                return result;
             else
                 result = new BackingStoreSerializationWriterProxyFactory(original);
 
@@ -69,6 +72,9 @@ namespace Microsoft.Kiota.Abstractions
                 if(registry != ParseNodeFactoryRegistry.DefaultInstance)// if the registry is the default instance, we already enabled it above. No need to do it twice
                     EnableBackingStoreForParseNodeRegistry(ParseNodeFactoryRegistry.DefaultInstance);
             }
+            if(result is BackingStoreParseNodeFactory)
+                //We are already enabled so use it.
+                return result;
             else
                 result = new BackingStoreParseNodeFactory(original);
 
@@ -80,7 +86,7 @@ namespace Microsoft.Kiota.Abstractions
             var keysToUpdate = new List<string>();
             foreach(var entry in registry.ContentTypeAssociatedFactories)
             {
-                if(entry.Value is not (BackingStoreSerializationWriterProxyFactory or SerializationWriterFactoryRegistry))
+                if(entry.Value is not BackingStoreParseNodeFactory)
                 {
                     keysToUpdate.Add(entry.Key);
                 }
@@ -97,7 +103,7 @@ namespace Microsoft.Kiota.Abstractions
             var keysToUpdate = new List<string>();
             foreach(var entry in registry.ContentTypeAssociatedFactories)
             {
-                if(entry.Value is not (BackingStoreSerializationWriterProxyFactory or SerializationWriterFactoryRegistry))
+                if(entry.Value is not BackingStoreSerializationWriterProxyFactory)
                 {
                     keysToUpdate.Add(entry.Key);
                 }


### PR DESCRIPTION
…uld not check to see if the supplied ParseNodeFactoryRegistry was already a BackingStoreParseNodeFactory. This means that if it was called in a loop it would add multiple layers of Backing Storage and the call to GetRootParseNode could end up making lots of calls. In dotnet 4.8 projects with Prefer 32 Bit Turned off, the large call stack was causing StackOverflow Exceptions.

To validate the assumption a static Count was added to ParseNodeProxyFactory and checked after each iteration. When a GraphServiceClient was created outside of the loop, there is only 1 call to EnableBackingStoreForParseNodeFactory and no problems results. If the GraphServiceClient were created inside of the loop, EnableBackingStoreForParseNodeFactory was getting called for each new graph client, which results in Count matching the number of interations of the Loop. Eventually it would die around 2300 iterations.

The static Field was removed from the code checked in.

```

        private static void GraphServiceClientInLoopFails()
        {
            var msGraphHttpClient = Microsoft.Graph.GraphClientFactory.Create();
            for(int i = 0; i < DefaultLoops; i++)
            {
                Microsoft.Kiota.Abstractions.Serialization.ParseNodeProxyFactory.Count = 0;
                var auth = new Microsoft.Kiota.Abstractions.Authentication.AnonymousAuthenticationProvider();
                var serviceClient = new Microsoft.Graph.GraphServiceClient(msGraphHttpClient, auth);

                Console.WriteLine(i);
                serviceClient
                    .Me
                    .Messages[Guid.NewGuid().ToString()]
                    .WithUrl(MessageUrl)
                    .GetAsync()
                    .Wait();
                Console.WriteLine($"Count\t{Microsoft.Kiota.Abstractions.Serialization.ParseNodeProxyFactory.Count}");
            }
        }

        private static void GraphServiceClientOutsideLoopSucceeds()
        {
            var msGraphHttpClient = Microsoft.Graph.GraphClientFactory.Create();
            var auth = new Microsoft.Kiota.Abstractions.Authentication.AnonymousAuthenticationProvider();
            var serviceClient = new Microsoft.Graph.GraphServiceClient(msGraphHttpClient, auth);

            for(int i = 0; i < DefaultLoops; i++)
            {
                Microsoft.Kiota.Abstractions.Serialization.ParseNodeProxyFactory.Count = 0;
                Console.WriteLine(i);
                serviceClient
                    .Me
                    .Messages[Guid.NewGuid().ToString()]
                    .WithUrl(MessageUrl)
                    .GetAsync()
                    .Wait();
                Console.WriteLine($"Count\t{Microsoft.Kiota.Abstractions.Serialization.ParseNodeProxyFactory.Count}");
            }
        }
```

Fixes https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/2588