### PR TITLE
Only track changed values when it matters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+
+## [1.12.4] - 2024-09-05
+
+### Changed
+
+- Improves performance of the InMemoryBackingStore when reading properties. [#347](https://github.com/microsoft/kiota-dotnet/issues/347)
+
 ## [1.12.3] - 2024-09-03
 
 ### Changed

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <!-- Common default project properties for ALL projects-->
   <PropertyGroup>
-    <VersionPrefix>1.12.3</VersionPrefix>
+    <VersionPrefix>1.12.4</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <!-- This is overidden in test projects by setting to true-->
     <IsTestProject>false</IsTestProject>

--- a/src/abstractions/store/InMemoryBackingStore.cs
+++ b/src/abstractions/store/InMemoryBackingStore.cs
@@ -253,9 +253,9 @@ namespace Microsoft.Kiota.Abstractions.Store
 
         private void ForwardReturnOnlyChangedValuesToNestedInstances()
         {
-            foreach(var item in store)
+            foreach(var item in store.Values)
             {
-                if(item.Value.Item2 is Tuple<ICollection, int> collectionTuple)
+                if(item.Item2 is Tuple<ICollection, int> collectionTuple)
                 {
                     foreach(var collectionItem in collectionTuple.Item1)
                     {
@@ -263,7 +263,7 @@ namespace Microsoft.Kiota.Abstractions.Store
                         backedModel.BackingStore.ReturnOnlyChangedValues = _returnOnlyChangedValues;
                     }
                 }
-                else if(item.Value.Item2 is IBackedModel backedModel)
+                else if(item.Item2 is IBackedModel backedModel)
                 {
                     backedModel.BackingStore.ReturnOnlyChangedValues = _returnOnlyChangedValues;
                 }

--- a/src/abstractions/store/InMemoryBackingStore.cs
+++ b/src/abstractions/store/InMemoryBackingStore.cs
@@ -15,10 +15,21 @@ namespace Microsoft.Kiota.Abstractions.Store
     public class InMemoryBackingStore : IBackingStore
     {
         private bool isInitializationComplete = true;
+        private bool _returnOnlyChangedValues = false;
+
         /// <summary>
         /// Determines whether the backing store should only return changed values when queried.
         /// </summary>
-        public bool ReturnOnlyChangedValues { get; set; }
+        public bool ReturnOnlyChangedValues
+        {
+            get => _returnOnlyChangedValues;
+
+            set
+            {
+                _returnOnlyChangedValues = value;
+                ForwardReturnOnlyChangedValuesToNestedInstances();
+            }
+        }
         private readonly ConcurrentDictionary<string, Tuple<bool, object?>> store = new();
         private readonly ConcurrentDictionary<string, Action<string, object?, object?>> subscriptions = new();
 
@@ -34,7 +45,10 @@ namespace Microsoft.Kiota.Abstractions.Store
 
             if(store.TryGetValue(key, out var result))
             {
-                EnsureCollectionPropertyIsConsistent(key, result.Item2);
+                if(ReturnOnlyChangedValues)
+                {
+                    EnsureCollectionPropertyIsConsistent(key, result.Item2);
+                }
                 var resultObject = result.Item2;
                 if(resultObject is Tuple<ICollection, int> collectionTuple)
                 {
@@ -128,6 +142,14 @@ namespace Microsoft.Kiota.Abstractions.Store
         /// <returns>A collection of strings containing keys changed to null </returns>
         public IEnumerable<string> EnumerateKeysForValuesChangedToNull()
         {
+            if(ReturnOnlyChangedValues) // refresh the state of collection properties if they've changed in size.
+            {
+                foreach(var item in store)
+                {
+                    EnsureCollectionPropertyIsConsistent(item.Key, item.Value.Item2);
+                }
+            }
+
             foreach(var item in store)
             {
                 if(item.Value.Item1 && item.Value.Item2 == null)
@@ -225,6 +247,25 @@ namespace Microsoft.Kiota.Abstractions.Store
                 foreach(var item in backedModel.BackingStore.Enumerate())
                 {
                     backedModel.BackingStore.Get<object>(item.Key);
+                }
+            }
+        }
+
+        private void ForwardReturnOnlyChangedValuesToNestedInstances()
+        {
+            foreach(var item in store)
+            {
+                if(item.Value.Item2 is Tuple<ICollection, int> collectionTuple)
+                {
+                    foreach(var collectionItem in collectionTuple.Item1)
+                    {
+                        if(collectionItem is not IBackedModel backedModel) break;
+                        backedModel.BackingStore.ReturnOnlyChangedValues = _returnOnlyChangedValues;
+                    }
+                }
+                else if(item.Value.Item2 is IBackedModel backedModel)
+                {
+                    backedModel.BackingStore.ReturnOnlyChangedValues = _returnOnlyChangedValues;
                 }
             }
         }

--- a/tests/abstractions/Store/InMemoryBackingStoreTests.cs
+++ b/tests/abstractions/Store/InMemoryBackingStoreTests.cs
@@ -487,6 +487,44 @@ namespace Microsoft.Kiota.Abstractions.Tests.Store
             Assert.InRange(stopWatch.ElapsedMilliseconds, 0, 1);
         }
 
+        [Fact]
+        public void TestsLargeObjectReadPerformsWell()
+        {
+            // Arrange dummy user with many child objects
+            var testUser = new TestEntity
+            {
+                Id = "84c747c1-d2c0-410d-ba50-fc23e0b4abbe",
+                Colleagues = Enumerable.Range(1, 100)
+                    .Select(_ => new TestEntity
+                    {
+                        Id = Guid.NewGuid().ToString(),
+                        BusinessPhones = new List<string>
+                        {
+                            "+1 234 567 891"
+                        },
+                        Colleagues = Enumerable.Range(1, 100)
+                            .Select(_ => new TestEntity
+                            {
+                                Id = Guid.NewGuid().ToString(),
+                                BusinessPhones = new List<string>
+                                {
+                                    "+1 234 567 891"
+                                }
+                            })
+                            .ToList()
+                    })
+                    .ToList()
+            };
+
+            // Act on the data by reading a property
+            var stopWatch = Stopwatch.StartNew();
+            _ = testUser.Colleagues[0];
+            stopWatch.Stop();
+
+            // Assert
+            Assert.InRange(stopWatch.ElapsedMilliseconds, 0, 1);
+        }
+
         /// <summary>
         /// Helper function to pull out the private `subscriptions` collection property from the InMemoryBackingStore class
         /// </summary>


### PR DESCRIPTION
As requested in #347 

The idea is to skip tracking the change state until the `ReturnOnlyChangedValues` property is true.