### PR TITLE
fix: serialization of primitives present in additionalData

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.14.1] - 2024-11-13
+
+### Added
+
+- Fixes serialization collections of primitives present in additional data. [microsoftgraph/msgraph-sdk-dotnet#2729](https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/2729)
+
 ## [1.14.0] - 2024-11-06
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.14.1] - 2024-11-13
+## [1.15.1] - 2024-11-13
 
 ### Added
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <!-- Common default project properties for ALL projects-->
   <PropertyGroup>
-    <VersionPrefix>1.14.0</VersionPrefix>
+    <VersionPrefix>1.15.1</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <!-- This is overidden in test projects by setting to true-->
     <IsTestProject>false</IsTestProject>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <!-- Common default project properties for ALL projects-->
   <PropertyGroup>
-    <VersionPrefix>1.14.0</VersionPrefix>
+    <VersionPrefix>1.14.1</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <!-- This is overidden in test projects by setting to true-->
     <IsTestProject>false</IsTestProject>

--- a/src/serialization/json/JsonSerializationWriter.cs
+++ b/src/serialization/json/JsonSerializationWriter.cs
@@ -1,4 +1,4 @@
-﻿// ------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------
 
@@ -311,7 +311,9 @@ namespace Microsoft.Kiota.Serialization.Json
         /// </summary>
         /// <param name="key">The key of the json node</param>
         /// <param name="values">The primitive collection</param>
-        public void WriteCollectionOfPrimitiveValues<T>(string? key, IEnumerable<T>? values)
+        public void WriteCollectionOfPrimitiveValues<T>(string? key, IEnumerable<T>? values) => WriteCollectionOfPrimitiveValuesInternal(key, values);
+
+        private void WriteCollectionOfPrimitiveValuesInternal(string? key, IEnumerable? values)
         {
             if(values != null)
             { //empty array is meaningful
@@ -525,9 +527,6 @@ namespace Microsoft.Kiota.Serialization.Json
                 case TimeSpan timeSpan:
                     WriteTimeSpanValue(key, timeSpan);
                     break;
-                case IEnumerable<object> coll:
-                    WriteCollectionOfPrimitiveValues(key, coll);
-                    break;
                 case UntypedNode node:
                     WriteUntypedValue(key, node);
                     break;
@@ -550,6 +549,9 @@ namespace Microsoft.Kiota.Serialization.Json
                     break;
                 case IDictionary dictionary:
                     WriteDictionaryValue(key, dictionary);
+                    break;
+                case IEnumerable coll:
+                    WriteCollectionOfPrimitiveValuesInternal(key, coll);
                     break;
                 case object o:
                     WriteNonParsableObjectValue(key, o);


### PR DESCRIPTION
Fixes https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/2729

The pattern matching in the code does not match a collection of stucts like DateTime or DateTimeOffsets leading to the error as its handled incorrecty. 
https://github.com/microsoft/kiota-dotnet/blob/cd987c2271d760ae81d3267a1af7782378acb90a/src/serialization/json/JsonSerializationWriter.cs#L528

