### PR TITLE
chore: uses nuget suppressions for CVEs

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,4 +17,10 @@
     <IsPackable>false</IsPackable>
     <OutputType>Library</OutputType>
   </PropertyGroup>
+  <ItemGroup>
+    <!-- The target application is the one which will resolve the correct version.
+     When the version range is updated to > 8.0.4 in the future, remove the GHSA suppression -->
+    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-hh2w-p6rv-4g7w" />
+    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-8g4q-xg66-9fp4" />
+  </ItemGroup>
 </Project>

--- a/src/http/httpClient/Microsoft.Kiota.Http.HttpClientLibrary.csproj
+++ b/src/http/httpClient/Microsoft.Kiota.Http.HttpClientLibrary.csproj
@@ -13,11 +13,7 @@
   <ItemGroup
     Condition="'$(TargetFramework)' == 'net5.0' or '$(TargetFramework)'== 'netStandard2.0' or '$(TargetFramework)' == 'netStandard2.1' or '$(TargetFramework)' == 'net462'">
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="[6.0,)" />
-    <!-- The target application is the one which will resolve the correct version.
-     When the version range is updated to > 8.0.4 in the future, remove the GHSA suppression -->
     <PackageReference Include="System.Text.Json" Version="[6.0,)" />
-    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-hh2w-p6rv-4g7w" />
-    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-8g4q-xg66-9fp4" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">

--- a/src/http/httpClient/Microsoft.Kiota.Http.HttpClientLibrary.csproj
+++ b/src/http/httpClient/Microsoft.Kiota.Http.HttpClientLibrary.csproj
@@ -13,10 +13,11 @@
   <ItemGroup
     Condition="'$(TargetFramework)' == 'net5.0' or '$(TargetFramework)'== 'netStandard2.0' or '$(TargetFramework)' == 'netStandard2.1' or '$(TargetFramework)' == 'net462'">
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="[6.0,)" />
-    <!-- suppressed because of this CVE https://github.com/advisories/GHSA-hh2w-p6rv-4g7w 
-     The target application is the one which will resolve the correct version
-     when the version range is updated to > 8.0.4 in the future, remove the nowarn suppression -->
-    <PackageReference Include="System.Text.Json" Version="[6.0,)" NoWarn="NU1903" />
+    <!-- The target application is the one which will resolve the correct version.
+     When the version range is updated to > 8.0.4 in the future, remove the GHSA suppression -->
+    <PackageReference Include="System.Text.Json" Version="[6.0,)" />
+    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-hh2w-p6rv-4g7w" />
+    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-8g4q-xg66-9fp4" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">

--- a/src/serialization/json/Microsoft.Kiota.Serialization.Json.csproj
+++ b/src/serialization/json/Microsoft.Kiota.Serialization.Json.csproj
@@ -14,10 +14,11 @@
   <!-- NET 5 target to be removed on next major version-->
   <ItemGroup
     Condition="'$(TargetFramework)' == 'net5.0' or '$(TargetFramework)'== 'netStandard2.0' or '$(TargetFramework)' == 'netStandard2.1'">
-    <!-- suppressed because of this CVE https://github.com/advisories/GHSA-hh2w-p6rv-4g7w
-     The target application is the one which will resolve the correct version
-     when the version range is updated to > 8.0.4 in the future, remove the nowarn suppression -->
-    <PackageReference Include="System.Text.Json" Version="[6.0,)" NoWarn="NU1903" />
+    <!-- The target application is the one which will resolve the correct version.
+     When the version range is updated to > 8.0.4 in the future, remove the GHSA suppression -->
+    <PackageReference Include="System.Text.Json" Version="[6.0,)" />
+    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-hh2w-p6rv-4g7w" />
+    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-8g4q-xg66-9fp4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/serialization/json/Microsoft.Kiota.Serialization.Json.csproj
+++ b/src/serialization/json/Microsoft.Kiota.Serialization.Json.csproj
@@ -14,11 +14,7 @@
   <!-- NET 5 target to be removed on next major version-->
   <ItemGroup
     Condition="'$(TargetFramework)' == 'net5.0' or '$(TargetFramework)'== 'netStandard2.0' or '$(TargetFramework)' == 'netStandard2.1'">
-    <!-- The target application is the one which will resolve the correct version.
-     When the version range is updated to > 8.0.4 in the future, remove the GHSA suppression -->
     <PackageReference Include="System.Text.Json" Version="[6.0,)" />
-    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-hh2w-p6rv-4g7w" />
-    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-8g4q-xg66-9fp4" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
uses nuget suppressions like in https://github.com/microsoft/OpenApi.ApiManifest/pull/119 so we're aware of any future CVE