### PR TITLE
MultiPartBody: Add Support for multiple Body Parts with the same name

### DIFF
--- a/src/abstractions/MultipartBody.cs
+++ b/src/abstractions/MultipartBody.cs
@@ -63,7 +63,21 @@ public class MultipartBody : IParsable
     /// <returns>The value of the part.</returns>
     public T? GetPartValue<T>(string partName)
     {
-        return GetPartValue<T>(partName, null);
+        var value = GetPartValue<T>(partName, null);
+
+        if(EqualityComparer<T?>.Default.Equals(value, default))
+        {
+            foreach(var key in _parts.Keys)
+            {
+                if(key.Item1 == partName)
+                {
+                    value = GetPartValue<T>(partName, key.Item2);
+                    break;
+                }
+            }
+        }
+
+        return value;
     }
     /// <summary>
     /// Gets the value of a part from the multipart body.
@@ -95,7 +109,21 @@ public class MultipartBody : IParsable
     /// <returns>True if the part was removed, false otherwise.</returns>   
     public bool RemovePart(string partName)
     {
-        return RemovePart(partName, null);
+        bool success = RemovePart(partName, null);
+
+        if(!success)
+        {
+            foreach(var key in _parts.Keys)
+            {
+                if(key.Item1 == partName)
+                {
+                    success = RemovePart(partName, key.Item2);
+                    break;
+                }
+            }
+        }
+
+        return success;
     }
 
     /// <summary>

--- a/src/abstractions/MultipartBody.cs
+++ b/src/abstractions/MultipartBody.cs
@@ -226,14 +226,14 @@ public class MultipartBody : IParsable
     {
         public bool Equals((string, string) x, (string, string) y)
         {
-            return StringComparer.OrdinalIgnoreCase.Equals(x.Item1, y.Item1) &&
-                   StringComparer.OrdinalIgnoreCase.Equals(x.Item2, y.Item2);
+            return StringComparer.Ordinal.Equals(x.Item1, y.Item1) &&
+                   StringComparer.Ordinal.Equals(x.Item2, y.Item2);
         }
 
         public int GetHashCode(ValueTuple<string, string?> obj)
         {
-            int hash1 = StringComparer.OrdinalIgnoreCase.GetHashCode(obj.Item1);
-            int hash2 = obj.Item2 != null ? StringComparer.OrdinalIgnoreCase.GetHashCode(obj.Item2) : 0;
+            int hash1 = StringComparer.Ordinal.GetHashCode(obj.Item1);
+            int hash2 = obj.Item2 != null ? StringComparer.Ordinal.GetHashCode(obj.Item2) : 0;
             return hash1 ^ hash2;
         }
     }

--- a/src/abstractions/MultipartBody.cs
+++ b/src/abstractions/MultipartBody.cs
@@ -54,6 +54,7 @@ public class MultipartBody : IParsable
             _parts[key] = value;
         }
     }
+    // TODO: Remove with next major release
     /// <summary>
     /// Gets the value of a part from the multipart body.
     /// </summary>
@@ -86,6 +87,7 @@ public class MultipartBody : IParsable
         }
         return default;
     }
+    // TODO: Remove with next major release
     /// <summary>
     /// Removes a part from the multipart body.
     /// </summary>

--- a/tests/abstractions/MultipartBodyTests.cs
+++ b/tests/abstractions/MultipartBodyTests.cs
@@ -104,8 +104,7 @@ public class MultipartBodyTests
         Assert.Equal("fileContent", body.GetPartValue<string>("file", "file.json"));
         Assert.Equal("fileContent2", body.GetPartValue<string>("file", "file2.json"));
 
-        //Assert part can only be removed if fileName is specified
-        Assert.False(body.RemovePart("file"));
+        //Assert part can be removed if fileName is specified
         Assert.True(body.RemovePart("file", "file.json"));
 
         //Assert file.json is removed and file2.json is still accessible

--- a/tests/abstractions/MultipartBodyTests.cs
+++ b/tests/abstractions/MultipartBodyTests.cs
@@ -114,7 +114,7 @@ public class MultipartBodyTests
     }
 
     [Fact]
-    public void ImplementationBreaksExisting()
+    public void MultiPartBodyExistingGetAndRemoveStillWork()
     {
         var body = new MultipartBody();
 
@@ -122,5 +122,8 @@ public class MultipartBodyTests
 
         // existing usecase, file should still be able to be retreived
         Assert.Equal("fileContent", body.GetPartValue<string>("file"));
+
+        // existing usecase, file should be sucesfully removed
+        Assert.True(body.RemovePart("file"));
     }
 }

--- a/tests/abstractions/MultipartBodyTests.cs
+++ b/tests/abstractions/MultipartBodyTests.cs
@@ -90,4 +90,37 @@ public class MultipartBodyTests
         requestAdapterMock.VerifyAll();
         serializationFactoryMock.VerifyAll();
     }
+
+
+    [Fact]
+    public void AllowsDuplicateEntries()
+    {
+        var body = new MultipartBody();
+
+        body.AddOrReplacePart("file", "application/json", "fileContent", "file.json");
+        body.AddOrReplacePart("file", "application/json", "fileContent2", "file2.json");
+
+        //Assert both files are stored in the body
+        Assert.Equal("fileContent", body.GetPartValue<string>("file", "file.json"));
+        Assert.Equal("fileContent2", body.GetPartValue<string>("file", "file2.json"));
+
+        //Assert part can only be removed if fileName is specified
+        Assert.False(body.RemovePart("file"));
+        Assert.True(body.RemovePart("file", "file.json"));
+
+        //Assert file.json is removed and file2.json is still accessible
+        Assert.Null(body.GetPartValue<string>("file", "file.json"));
+        Assert.Equal("fileContent2", body.GetPartValue<string>("file", "file2.json"));
+    }
+
+    [Fact]
+    public void ImplementationBreaksExisting()
+    {
+        var body = new MultipartBody();
+
+        body.AddOrReplacePart("file", "application/json", "fileContent", "file.json");
+
+        // existing usecase, file should still be able to be retreived
+        Assert.Equal("fileContent", body.GetPartValue<string>("file"));
+    }
 }


### PR DESCRIPTION
- change MultiPartbody internal dictionary key from string to Tuple<string, string?)
- Add additional method overloads for GetPartValue<T> RemovePart
- Add EqualityComparer fro Tuple<string, string?>
- Add failing Test showcasing the imminent breaking change
- Add passing Test verifying the new intened behaviour

Fixes: #529

