### PR TITLE
Feat: deserialize numbers as strings

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,6 +53,6 @@ The recommended commit types used are:
 - __docs__ for documentation updates e.g. ReadMe update or code documentation updates
 - __build__ for build system changes (gradle updates, external dependency updates)
 - __ci__ for CI configuration file changes e.g. updating a pipeline
-- __chore__ for miscallaneous non-sdk changesin the repo e.g. removing an unused file
+- __chore__ for miscallaneous non-sdk changes in the repo e.g. removing an unused file
 
 Adding an exclamation mark after the commit type (`feat!`) or footer with the prefix __BREAKING CHANGE:__ will cause an increment of the _major_ version.

--- a/src/serialization/json/JsonParseNode.cs
+++ b/src/serialization/json/JsonParseNode.cs
@@ -113,7 +113,7 @@ namespace Microsoft.Kiota.Serialization.Json
         /// Get the double value from the json node
         /// </summary>
         /// <returns>A double value</returns>
-        public double? GetDoubleValue() => _jsonNode.ValueKind == JsonValueKind.Number
+        public double? GetDoubleValue() => (_jsonNode.ValueKind == JsonValueKind.Number || (_jsonNode.ValueKind == JsonValueKind.String && _jsonSerializerContext.Options.NumberHandling.HasFlag(JsonNumberHandling.AllowReadingFromString)))
             ? _jsonNode.Deserialize(_jsonSerializerContext.Double)
             : null;
 

--- a/src/serialization/json/JsonParseNode.cs
+++ b/src/serialization/json/JsonParseNode.cs
@@ -97,7 +97,7 @@ namespace Microsoft.Kiota.Serialization.Json
         /// Get the float value from the json node
         /// </summary>
         /// <returns>A float value</returns>
-        public float? GetFloatValue() => _jsonNode.ValueKind == JsonValueKind.Number
+        public float? GetFloatValue() => (_jsonNode.ValueKind == JsonValueKind.Number || (_jsonNode.ValueKind == JsonValueKind.String && _jsonSerializerContext.Options.NumberHandling.HasFlag(JsonNumberHandling.AllowReadingFromString)))
             ? _jsonNode.Deserialize(_jsonSerializerContext.Single)
             : null;
 

--- a/src/serialization/json/JsonParseNode.cs
+++ b/src/serialization/json/JsonParseNode.cs
@@ -89,15 +89,16 @@ namespace Microsoft.Kiota.Serialization.Json
         /// Get the int value from the json node
         /// </summary>
         /// <returns>A int value</returns>
-        public int? GetIntValue() => (_jsonNode.ValueKind == JsonValueKind.Number || (_jsonNode.ValueKind == JsonValueKind.String && _jsonSerializerContext.Options.NumberHandling.HasFlag(JsonNumberHandling.AllowReadingFromString)))
+        public int? GetIntValue() => IsParsableNumber(_jsonNode.ValueKind, _jsonSerializerContext.Options.NumberHandling)
             ? _jsonNode.Deserialize(_jsonSerializerContext.Int32)
             : null;
+
 
         /// <summary>
         /// Get the float value from the json node
         /// </summary>
         /// <returns>A float value</returns>
-        public float? GetFloatValue() => (_jsonNode.ValueKind == JsonValueKind.Number || (_jsonNode.ValueKind == JsonValueKind.String && _jsonSerializerContext.Options.NumberHandling.HasFlag(JsonNumberHandling.AllowReadingFromString)))
+        public float? GetFloatValue() => IsParsableNumber(_jsonNode.ValueKind, _jsonSerializerContext.Options.NumberHandling)
             ? _jsonNode.Deserialize(_jsonSerializerContext.Single)
             : null;
 
@@ -105,7 +106,7 @@ namespace Microsoft.Kiota.Serialization.Json
         /// Get the Long value from the json node
         /// </summary>
         /// <returns>A Long value</returns>
-        public long? GetLongValue() => (_jsonNode.ValueKind == JsonValueKind.Number || (_jsonNode.ValueKind == JsonValueKind.String && _jsonSerializerContext.Options.NumberHandling.HasFlag(JsonNumberHandling.AllowReadingFromString)))
+        public long? GetLongValue() => IsParsableNumber(_jsonNode.ValueKind, _jsonSerializerContext.Options.NumberHandling)
             ? _jsonNode.Deserialize(_jsonSerializerContext.Int64)
             : null;
 
@@ -113,7 +114,7 @@ namespace Microsoft.Kiota.Serialization.Json
         /// Get the double value from the json node
         /// </summary>
         /// <returns>A double value</returns>
-        public double? GetDoubleValue() => (_jsonNode.ValueKind == JsonValueKind.Number || (_jsonNode.ValueKind == JsonValueKind.String && _jsonSerializerContext.Options.NumberHandling.HasFlag(JsonNumberHandling.AllowReadingFromString)))
+        public double? GetDoubleValue() => IsParsableNumber(_jsonNode.ValueKind, _jsonSerializerContext.Options.NumberHandling)
             ? _jsonNode.Deserialize(_jsonSerializerContext.Double)
             : null;
 
@@ -121,9 +122,16 @@ namespace Microsoft.Kiota.Serialization.Json
         /// Get the decimal value from the json node
         /// </summary>
         /// <returns>A decimal value</returns>
-        public decimal? GetDecimalValue() => (_jsonNode.ValueKind == JsonValueKind.Number || (_jsonNode.ValueKind == JsonValueKind.String && _jsonSerializerContext.Options.NumberHandling.HasFlag(JsonNumberHandling.AllowReadingFromString)))
+        public decimal? GetDecimalValue() => IsParsableNumber(_jsonNode.ValueKind, _jsonSerializerContext.Options.NumberHandling)
             ? _jsonNode.Deserialize(_jsonSerializerContext.Decimal)
             : null;
+
+        private static bool IsParsableNumber(JsonValueKind valueKind, JsonNumberHandling numberHandling) => valueKind switch
+        {
+            JsonValueKind.Number => true,
+            JsonValueKind.String when numberHandling.HasFlag(JsonNumberHandling.AllowReadingFromString) => true,
+            _ => false
+        };
 
         /// <summary>
         /// Get the guid value from the json node

--- a/src/serialization/json/JsonParseNode.cs
+++ b/src/serialization/json/JsonParseNode.cs
@@ -15,6 +15,8 @@ using Microsoft.Kiota.Abstractions;
 using Microsoft.Kiota.Abstractions.Extensions;
 using Microsoft.Kiota.Abstractions.Helpers;
 using Microsoft.Kiota.Abstractions.Serialization;
+using System.Text.Json.Serialization;
+
 
 #if NET5_0_OR_GREATER
 using System.Diagnostics.CodeAnalysis;
@@ -87,7 +89,7 @@ namespace Microsoft.Kiota.Serialization.Json
         /// Get the int value from the json node
         /// </summary>
         /// <returns>A int value</returns>
-        public int? GetIntValue() => _jsonNode.ValueKind == JsonValueKind.Number
+        public int? GetIntValue() => (_jsonNode.ValueKind == JsonValueKind.Number || (_jsonNode.ValueKind == JsonValueKind.String && _jsonSerializerContext.Options.NumberHandling.HasFlag(JsonNumberHandling.AllowReadingFromString)))
             ? _jsonNode.Deserialize(_jsonSerializerContext.Int32)
             : null;
 

--- a/src/serialization/json/JsonParseNode.cs
+++ b/src/serialization/json/JsonParseNode.cs
@@ -121,7 +121,7 @@ namespace Microsoft.Kiota.Serialization.Json
         /// Get the decimal value from the json node
         /// </summary>
         /// <returns>A decimal value</returns>
-        public decimal? GetDecimalValue() => _jsonNode.ValueKind == JsonValueKind.Number
+        public decimal? GetDecimalValue() => (_jsonNode.ValueKind == JsonValueKind.Number || (_jsonNode.ValueKind == JsonValueKind.String && _jsonSerializerContext.Options.NumberHandling.HasFlag(JsonNumberHandling.AllowReadingFromString)))
             ? _jsonNode.Deserialize(_jsonSerializerContext.Decimal)
             : null;
 

--- a/src/serialization/json/JsonParseNode.cs
+++ b/src/serialization/json/JsonParseNode.cs
@@ -105,7 +105,7 @@ namespace Microsoft.Kiota.Serialization.Json
         /// Get the Long value from the json node
         /// </summary>
         /// <returns>A Long value</returns>
-        public long? GetLongValue() => _jsonNode.ValueKind == JsonValueKind.Number
+        public long? GetLongValue() => (_jsonNode.ValueKind == JsonValueKind.Number || (_jsonNode.ValueKind == JsonValueKind.String && _jsonSerializerContext.Options.NumberHandling.HasFlag(JsonNumberHandling.AllowReadingFromString)))
             ? _jsonNode.Deserialize(_jsonSerializerContext.Int64)
             : null;
 

--- a/tests/serialization/json/JsonParseNodeTests.cs
+++ b/tests/serialization/json/JsonParseNodeTests.cs
@@ -2,6 +2,7 @@
 using System.Globalization;
 using System.Linq;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Threading;
 using Microsoft.Kiota.Abstractions;
 using Microsoft.Kiota.Abstractions.Serialization;
@@ -532,6 +533,116 @@ namespace Microsoft.Kiota.Serialization.Json.Tests
             Assert.Equal(12, result.Value.Hour);
             Assert.Equal(34, result.Value.Minute);
             Assert.Equal(56, result.Value.Second);
+        }
+
+        [Theory]
+        [InlineData("42", 42)]
+        [InlineData("\"42\"", null)]
+        [InlineData("null", null)]
+        public void GetIntValue_CanReadNumber(string input, int? expected)
+        {
+            // Arrange
+            using var jsonDocument = JsonDocument.Parse(input);
+            var parseNode = new JsonParseNode(jsonDocument.RootElement);
+
+            // Act
+            var actual = parseNode.GetIntValue();
+
+            // Assert
+            Assert.Equal(expected.HasValue, actual.HasValue);
+            if(expected.HasValue && actual.HasValue)
+            {
+                Assert.Equal(expected.Value, actual.Value);
+            }
+        }
+
+        [Theory]
+        [InlineData("42", 42L)]
+        [InlineData("\"42\"", null)]
+        [InlineData("null", null)]
+        public void GetLongValue_CanReadNumber(string input, long? expected)
+        {
+            // Arrange
+            using var jsonDocument = JsonDocument.Parse(input);
+            var parseNode = new JsonParseNode(jsonDocument.RootElement);
+
+            // Act
+            var actual = parseNode.GetLongValue();
+
+            // Assert
+            Assert.Equal(expected.HasValue, actual.HasValue);
+            if(expected.HasValue && actual.HasValue)
+            {
+                Assert.Equal(expected.Value, actual.Value);
+            }
+        }
+
+        [Theory]
+        [InlineData("13.37", 13.37F)]
+        [InlineData("\"13.37\"", null)]
+        [InlineData("null", null)]
+        public void GetFloatValue_CanReadNumber(string input, float? expected)
+        {
+            // Arrange
+            using var jsonDocument = JsonDocument.Parse(input);
+            var parseNode = new JsonParseNode(jsonDocument.RootElement);
+
+            // Act
+            var actual = parseNode.GetFloatValue();
+
+            // Assert
+            Assert.Equal(expected.HasValue, actual.HasValue);
+            if(expected.HasValue && actual.HasValue)
+            {
+                Assert.Equal(expected.Value, actual.Value);
+            }
+        }
+
+        [Theory]
+        [InlineData("13.37", 13.37D)]
+        [InlineData("\"13.37\"", null)]
+        [InlineData("null", null)]
+        public void GetDoubleValue_CanReadNumber(string input, double? expected)
+        {
+            // Arrange
+            using var jsonDocument = JsonDocument.Parse(input);
+            var parseNode = new JsonParseNode(jsonDocument.RootElement);
+
+            // Act
+            var actual = parseNode.GetDoubleValue();
+
+            // Assert
+            Assert.Equal(expected.HasValue, actual.HasValue);
+            if(expected.HasValue && actual.HasValue)
+            {
+                Assert.Equal(expected.Value, actual.Value);
+            }
+        }
+
+        [Theory]
+        [InlineData("13.37", 13.37)]
+        [InlineData("\"13.37\"", null)]
+        [InlineData("null", null)]
+        public void GetDecimalValue_CanReadNumber(string input, double? expectedDouble)
+        {
+            // Arrange
+            var expected = expectedDouble.HasValue
+                ? Convert.ToDecimal(expectedDouble)
+                : default(decimal?)
+            ; //13.37M is not supported as a constant expression in attributes
+
+            using var jsonDocument = JsonDocument.Parse(input);
+            var parseNode = new JsonParseNode(jsonDocument.RootElement);
+
+            // Act
+            var actual = parseNode.GetDecimalValue();
+
+            // Assert
+            Assert.Equal(expected.HasValue, actual.HasValue);
+            if(expected.HasValue && actual.HasValue)
+            {
+                Assert.Equal(expected.Value, actual.Value);
+            }
         }
     }
 }

--- a/tests/serialization/json/JsonParseNodeTests.cs
+++ b/tests/serialization/json/JsonParseNodeTests.cs
@@ -606,6 +606,27 @@ namespace Microsoft.Kiota.Serialization.Json.Tests
         }
 
         [Theory]
+        [InlineData("42", 42L)]
+        [InlineData("\"42\"", 42L)]
+        [InlineData("null", null)]
+        public void GetLongValue_CanReadNumber_AsString(string input, long? expected)
+        {
+            // Arrange
+            using var jsonDocument = JsonDocument.Parse(input);
+            var parseNode = new JsonParseNode(jsonDocument.RootElement, readNumbersAsStringsContext);
+
+            // Act
+            var actual = parseNode.GetLongValue();
+
+            // Assert
+            Assert.Equal(expected.HasValue, actual.HasValue);
+            if(expected.HasValue && actual.HasValue)
+            {
+                Assert.Equal(expected.Value, actual.Value);
+            }
+        }
+
+        [Theory]
         [InlineData("13.37", 13.37F)]
         [InlineData("\"13.37\"", null)]
         [InlineData("null", null)]

--- a/tests/serialization/json/JsonParseNodeTests.cs
+++ b/tests/serialization/json/JsonParseNodeTests.cs
@@ -735,5 +735,31 @@ namespace Microsoft.Kiota.Serialization.Json.Tests
                 Assert.Equal(expected.Value, actual.Value);
             }
         }
+
+        [Theory]
+        [InlineData("13.37", 13.37)]
+        [InlineData("\"13.37\"", 13.37)]
+        [InlineData("null", null)]
+        public void GetDecimalValue_CanReadNumber_AsString(string input, double? expectedDouble)
+        {
+            // Arrange
+            var expected = expectedDouble.HasValue
+                ? Convert.ToDecimal(expectedDouble)
+                : default(decimal?)
+            ; //13.37M is not supported as a constant expression in attributes
+
+            using var jsonDocument = JsonDocument.Parse(input);
+            var parseNode = new JsonParseNode(jsonDocument.RootElement, readNumbersAsStringsContext);
+
+            // Act
+            var actual = parseNode.GetDecimalValue();
+
+            // Assert
+            Assert.Equal(expected.HasValue, actual.HasValue);
+            if(expected.HasValue && actual.HasValue)
+            {
+                Assert.Equal(expected.Value, actual.Value);
+            }
+        }
     }
 }

--- a/tests/serialization/json/JsonParseNodeTests.cs
+++ b/tests/serialization/json/JsonParseNodeTests.cs
@@ -538,6 +538,7 @@ namespace Microsoft.Kiota.Serialization.Json.Tests
         [Theory]
         [InlineData("42", 42)]
         [InlineData("\"42\"", null)]
+        [InlineData("\"NotAnNumber\"", null)]
         [InlineData("null", null)]
         public void GetIntValue_CanReadNumber(string input, int? expected)
         {
@@ -566,6 +567,7 @@ namespace Microsoft.Kiota.Serialization.Json.Tests
         [Theory]
         [InlineData("42", 42)]
         [InlineData("\"42\"", 42)]
+        [InlineData("\"NotAnNumber\"", null)]
         [InlineData("null", null)]
         public void GetIntValue_CanReadNumber_AsString(string input, int? expected)
         {
@@ -587,6 +589,7 @@ namespace Microsoft.Kiota.Serialization.Json.Tests
         [Theory]
         [InlineData("42", 42L)]
         [InlineData("\"42\"", null)]
+        [InlineData("\"NotAnNumber\"", null)]
         [InlineData("null", null)]
         public void GetLongValue_CanReadNumber(string input, long? expected)
         {
@@ -608,6 +611,7 @@ namespace Microsoft.Kiota.Serialization.Json.Tests
         [Theory]
         [InlineData("42", 42L)]
         [InlineData("\"42\"", 42L)]
+        [InlineData("\"NotAnNumber\"", null)]
         [InlineData("null", null)]
         public void GetLongValue_CanReadNumber_AsString(string input, long? expected)
         {
@@ -629,6 +633,7 @@ namespace Microsoft.Kiota.Serialization.Json.Tests
         [Theory]
         [InlineData("13.37", 13.37F)]
         [InlineData("\"13.37\"", null)]
+        [InlineData("\"NotAnNumber\"", null)]
         [InlineData("null", null)]
         public void GetFloatValue_CanReadNumber(string input, float? expected)
         {
@@ -650,6 +655,7 @@ namespace Microsoft.Kiota.Serialization.Json.Tests
         [Theory]
         [InlineData("13.37", 13.37F)]
         [InlineData("\"13.37\"", 13.37F)]
+        [InlineData("\"NotAnNumber\"", null)]
         [InlineData("null", null)]
         public void GetFloatValue_CanReadNumber_AsString(string input, float? expected)
         {
@@ -671,6 +677,7 @@ namespace Microsoft.Kiota.Serialization.Json.Tests
         [Theory]
         [InlineData("13.37", 13.37D)]
         [InlineData("\"13.37\"", null)]
+        [InlineData("\"NotAnNumber\"", null)]
         [InlineData("null", null)]
         public void GetDoubleValue_CanReadNumber(string input, double? expected)
         {
@@ -692,6 +699,7 @@ namespace Microsoft.Kiota.Serialization.Json.Tests
         [Theory]
         [InlineData("13.37", 13.37D)]
         [InlineData("\"13.37\"", 13.37D)]
+        [InlineData("\"NotAnNumber\"", null)]
         [InlineData("null", null)]
         public void GetDoubleValue_CanReadNumber_AsString(string input, double? expected)
         {
@@ -713,6 +721,7 @@ namespace Microsoft.Kiota.Serialization.Json.Tests
         [Theory]
         [InlineData("13.37", 13.37)]
         [InlineData("\"13.37\"", null)]
+        [InlineData("\"NotAnNumber\"", null)]
         [InlineData("null", null)]
         public void GetDecimalValue_CanReadNumber(string input, double? expectedDouble)
         {
@@ -739,6 +748,7 @@ namespace Microsoft.Kiota.Serialization.Json.Tests
         [Theory]
         [InlineData("13.37", 13.37)]
         [InlineData("\"13.37\"", 13.37)]
+        [InlineData("\"NotAnNumber\"", null)]
         [InlineData("null", null)]
         public void GetDecimalValue_CanReadNumber_AsString(string input, double? expectedDouble)
         {

--- a/tests/serialization/json/JsonParseNodeTests.cs
+++ b/tests/serialization/json/JsonParseNodeTests.cs
@@ -697,7 +697,7 @@ namespace Microsoft.Kiota.Serialization.Json.Tests
         {
             // Arrange
             using var jsonDocument = JsonDocument.Parse(input);
-            var parseNode = new JsonParseNode(jsonDocument.RootElement);
+            var parseNode = new JsonParseNode(jsonDocument.RootElement, readNumbersAsStringsContext);
 
             // Act
             var actual = parseNode.GetDoubleValue();

--- a/tests/serialization/json/JsonParseNodeTests.cs
+++ b/tests/serialization/json/JsonParseNodeTests.cs
@@ -556,6 +556,34 @@ namespace Microsoft.Kiota.Serialization.Json.Tests
             }
         }
 
+        static KiotaJsonSerializationContext readNumbersAsStringsContext = new KiotaJsonSerializationContext(
+            new JsonSerializerOptions()
+            {
+                NumberHandling = JsonNumberHandling.AllowReadingFromString
+            }
+        );
+
+        [Theory]
+        [InlineData("42", 42)]
+        [InlineData("\"42\"", 42)]
+        [InlineData("null", null)]
+        public void GetIntValue_CanReadNumber_AsString(string input, int? expected)
+        {
+            // Arrange
+            using var jsonDocument = JsonDocument.Parse(input);
+            var parseNode = new JsonParseNode(jsonDocument.RootElement, readNumbersAsStringsContext);
+
+            // Act
+            var actual = parseNode.GetIntValue();
+
+            // Assert
+            Assert.Equal(expected.HasValue, actual.HasValue);
+            if(expected.HasValue && actual.HasValue)
+            {
+                Assert.Equal(expected.Value, actual.Value);
+            }
+        }
+
         [Theory]
         [InlineData("42", 42L)]
         [InlineData("\"42\"", null)]

--- a/tests/serialization/json/JsonParseNodeTests.cs
+++ b/tests/serialization/json/JsonParseNodeTests.cs
@@ -690,6 +690,27 @@ namespace Microsoft.Kiota.Serialization.Json.Tests
         }
 
         [Theory]
+        [InlineData("13.37", 13.37D)]
+        [InlineData("\"13.37\"", 13.37D)]
+        [InlineData("null", null)]
+        public void GetDoubleValue_CanReadNumber_AsString(string input, double? expected)
+        {
+            // Arrange
+            using var jsonDocument = JsonDocument.Parse(input);
+            var parseNode = new JsonParseNode(jsonDocument.RootElement);
+
+            // Act
+            var actual = parseNode.GetDoubleValue();
+
+            // Assert
+            Assert.Equal(expected.HasValue, actual.HasValue);
+            if(expected.HasValue && actual.HasValue)
+            {
+                Assert.Equal(expected.Value, actual.Value);
+            }
+        }
+
+        [Theory]
         [InlineData("13.37", 13.37)]
         [InlineData("\"13.37\"", null)]
         [InlineData("null", null)]

--- a/tests/serialization/json/JsonParseNodeTests.cs
+++ b/tests/serialization/json/JsonParseNodeTests.cs
@@ -648,6 +648,27 @@ namespace Microsoft.Kiota.Serialization.Json.Tests
         }
 
         [Theory]
+        [InlineData("13.37", 13.37F)]
+        [InlineData("\"13.37\"", 13.37F)]
+        [InlineData("null", null)]
+        public void GetFloatValue_CanReadNumber_AsString(string input, float? expected)
+        {
+            // Arrange
+            using var jsonDocument = JsonDocument.Parse(input);
+            var parseNode = new JsonParseNode(jsonDocument.RootElement, readNumbersAsStringsContext);
+
+            // Act
+            var actual = parseNode.GetFloatValue();
+
+            // Assert
+            Assert.Equal(expected.HasValue, actual.HasValue);
+            if(expected.HasValue && actual.HasValue)
+            {
+                Assert.Equal(expected.Value, actual.Value);
+            }
+        }
+
+        [Theory]
         [InlineData("13.37", 13.37D)]
         [InlineData("\"13.37\"", null)]
         [InlineData("null", null)]


### PR DESCRIPTION
# Synopsis

Enables opt-in support for deserializing "numbers as strings", by providing a configured `KiotaJsonSerializationContext`, in accordance to [JsonSerializerOptions.NumberHandling](https://learn.microsoft.com/en-us/dotnet/api/system.text.json.jsonserializeroptions.numberhandling?view=net-9.0).

This is to provide a more streamlined approach when dealing with APIs, which may return numbers as strings, even when their openAPI specifies a more specific type, like 

```json
"type": "number",
"format": "double"
```

where the current behavior is to fail silently, while populating such properties with `null`.

Closes https://github.com/microsoft/kiota-dotnet/issues/550

## via `JsonSerializerOptions.Web`
```csharp
var context = new KiotaJsonSerializationContext(new JsonSerializerOptions(JsonSerializerOptions.Web)); // can handle numbers-as-strings per default

var apiClient = new ApiClient(new HttpClientRequestAdapter
(
    parseNodeFactory: new JsonParseNodeFactory(context),
    httpClient: client
));
```

## via customized `JsonSerializerOptions`
```csharp
var context = new KiotaJsonSerializationContext(new JsonSerializerOptions()
{
    NumberHandling = JsonNumberHandling.AllowReadingFromString
}
var apiClient = new ApiClient(new HttpClientRequestAdapter
(
    parseNodeFactory: new JsonParseNodeFactory(context),
    httpClient: client
));
```