### PR TITLE
Sanitize IDictionary query parameters to skip null values

### DIFF
--- a/src/abstractions/RequestInformation.cs
+++ b/src/abstractions/RequestInformation.cs
@@ -114,8 +114,27 @@ namespace Microsoft.Kiota.Abstractions
         private static object GetSanitizedValues(object value) => value switch
         {
             Array array => ExpandArray(array),
+            IDictionary dict => SanitizeDictionary(dict),
             _ => GetSanitizedValue(value),
         };
+
+        /// <summary>
+        /// Pre-processes an <see cref="IDictionary"/> for <c>Std.UriTemplate</c> expansion.
+        /// Null values are skipped: RFC 6570 §2.3 states "if the value is undefined,
+        /// the variable expansion results in no output". Use <c>""</c> to send <c>?key=</c> (empty value).
+        /// </summary>
+        private static Dictionary<string, string> SanitizeDictionary(IDictionary dict)
+        {
+            var result = new Dictionary<string, string>(dict.Count);
+            foreach(DictionaryEntry entry in dict)
+            {
+                if(entry.Value is not null)
+                {
+                    result[(string)entry.Key] = GetSanitizedValue(entry.Value).ToString()!;
+                }
+            }
+            return result;
+        }
 
         /// <summary>
         /// Sanitizes objects in order to appear appropriately in the URL

--- a/src/abstractions/RequestInformation.cs
+++ b/src/abstractions/RequestInformation.cs
@@ -123,14 +123,14 @@ namespace Microsoft.Kiota.Abstractions
         /// Null values are skipped: RFC 6570 §2.3 states "if the value is undefined,
         /// the variable expansion results in no output". Use <c>""</c> to send <c>?key=</c> (empty value).
         /// </summary>
-        private static Dictionary<string, string> SanitizeDictionary(IDictionary dict)
+        private static Dictionary<string, object> SanitizeDictionary(IDictionary dict)
         {
-            var result = new Dictionary<string, string>(dict.Count);
+            var result = new Dictionary<string, object>(dict.Count);
             foreach(DictionaryEntry entry in dict)
             {
                 if(entry.Value is not null)
                 {
-                    result[(string)entry.Key] = GetSanitizedValue(entry.Value).ToString()!;
+                    result[entry.Key.ToString()!] = GetSanitizedValues(entry.Value);
                 }
             }
             return result;

--- a/tests/abstractions/RequestInformationTests.cs
+++ b/tests/abstractions/RequestInformationTests.cs
@@ -833,6 +833,123 @@ namespace Microsoft.Kiota.Abstractions.Tests
             Assert.Throws<ArgumentException>(() => requestInfo.URI.OriginalString);
         }
 
+        [Fact]
+        public void SetsDictionaryQueryParameterExpandsToKeyValuePairs()
+        {
+            // Arrange
+            var requestInfo = new RequestInformation
+            {
+                HttpMethod = Method.GET,
+                UrlTemplate = "http://localhost/articles{?query*}"
+            };
+
+            // Act — directly set a non-null dictionary; {?query*} explodes it into individual key=value pairs
+            requestInfo.QueryParameters.Add("query", new Dictionary<string, string?>
+            {
+                ["filter"] = "equals(published,'true')",
+                ["sort"] = "-createdAt"
+            });
+
+            // Assert
+            var url = requestInfo.URI.OriginalString;
+            Assert.Contains("filter=equals", url);
+            Assert.Contains("sort=-createdAt", url);
+        }
+
+        [Fact]
+        public void SetsDictionaryQueryParameterSkipsNullValues()
+        {
+            // Arrange
+            var requestInfo = new RequestInformation
+            {
+                HttpMethod = Method.GET,
+                UrlTemplate = "http://localhost/articles{?query*}"
+            };
+
+            // Act — null value for "include" must be silently dropped (RFC 6570 §2.3 undefined semantics)
+            requestInfo.QueryParameters.Add("query", new Dictionary<string, string?>
+            {
+                ["filter"] = "equals(published,'true')",
+                ["include"] = null,
+                ["sort"] = "-createdAt"
+            });
+
+            // Assert
+            var url = requestInfo.URI.OriginalString;
+            Assert.DoesNotContain("include", url);
+            Assert.Contains("filter=equals", url);
+            Assert.Contains("sort=-createdAt", url);
+        }
+
+        [Fact]
+        public void SetsDictionaryQueryParameterIncludesEmptyStringValues()
+        {
+            // Arrange
+            var requestInfo = new RequestInformation
+            {
+                HttpMethod = Method.GET,
+                UrlTemplate = "http://localhost/articles{?query*}"
+            };
+
+            // Act — an explicit empty string must produce ?key= (key present with empty value)
+            requestInfo.QueryParameters.Add("query", new Dictionary<string, string?>
+            {
+                ["filter"] = ""
+            });
+
+            // Assert
+            Assert.Contains("filter=", requestInfo.URI.OriginalString);
+        }
+
+        [Fact]
+        public void SetsDictionaryQueryParameterWithAllNullValuesProducesNoQueryString()
+        {
+            // Arrange
+            var requestInfo = new RequestInformation
+            {
+                HttpMethod = Method.GET,
+                UrlTemplate = "http://localhost/articles{?query*}"
+            };
+
+            // Act — when every value is null, SanitizeDictionary returns an empty dict and
+            // Std.UriTemplate omits the variable entirely (no '?' in the output)
+            requestInfo.QueryParameters.Add("query", new Dictionary<string, string?>
+            {
+                ["filter"] = null,
+                ["sort"] = null
+            });
+
+            // Assert
+            Assert.Equal("http://localhost/articles", requestInfo.URI.OriginalString);
+        }
+
+        [Fact]
+        public void SetsDictionaryQueryParameterViaAddQueryParameters()
+        {
+            // Arrange
+            var requestInfo = new RequestInformation
+            {
+                HttpMethod = Method.GET,
+                UrlTemplate = "http://localhost/articles{?query*}"
+            };
+
+            // Act — exercise the AddQueryParameters → QueryParameters → GetSanitizedValues path
+            requestInfo.AddQueryParameters(new GetQueryParameters
+            {
+                Query = new Dictionary<string, string?>
+                {
+                    ["page[size]"] = "10",
+                    ["include"] = "author"
+                }
+            });
+
+            // Assert
+            var url = requestInfo.URI.OriginalString;
+            Assert.Contains("include=author", url);
+            // page[size] key is percent-encoded by RFC 6570 {?} operator
+            Assert.Contains("page", url);
+            Assert.Contains("10", url);
+        }
 
     }
 
@@ -872,5 +989,7 @@ namespace Microsoft.Kiota.Abstractions.Tests
         public object? Item { get; set; }
         [QueryParameter("items")]
         public object[]? Items { get; set; }
+        [QueryParameter("query")]
+        public IDictionary<string, string?>? Query { get; set; }
     }
 }

--- a/tests/abstractions/RequestInformationTests.cs
+++ b/tests/abstractions/RequestInformationTests.cs
@@ -936,7 +936,7 @@ namespace Microsoft.Kiota.Abstractions.Tests
             // Act — exercise the AddQueryParameters → QueryParameters → GetSanitizedValues path
             requestInfo.AddQueryParameters(new GetQueryParameters
             {
-                Query = new Dictionary<string, string?>
+                Query = new Dictionary<string, object?>
                 {
                     ["page[size]"] = "10",
                     ["include"] = "author"
@@ -949,6 +949,31 @@ namespace Microsoft.Kiota.Abstractions.Tests
             // page[size] key is percent-encoded by RFC 6570 {?} operator
             Assert.Contains("page", url);
             Assert.Contains("10", url);
+        }
+
+        [Fact]
+        public void SetsDictionaryQueryParameterWithNonStringValues()
+        {
+            // Arrange
+            var requestInfo = new RequestInformation
+            {
+                HttpMethod = Method.GET,
+                UrlTemplate = "http://localhost/articles{?query*}"
+            };
+
+            // Act — dictionary containing numbers, booleans, and dates
+            requestInfo.QueryParameters.Add("query", new Dictionary<string, object?>
+            {
+                ["page"] = 2,
+                ["active"] = true,
+                ["created"] = new DateTimeOffset(2026, 7, 24, 0, 0, 0, TimeSpan.Zero)
+            });
+
+            // Assert
+            var url = requestInfo.URI.OriginalString;
+            Assert.Contains("page=2", url);
+            Assert.Contains("active=true", url);
+            Assert.Contains("created=2026", url);
         }
 
     }
@@ -990,6 +1015,6 @@ namespace Microsoft.Kiota.Abstractions.Tests
         [QueryParameter("items")]
         public object[]? Items { get; set; }
         [QueryParameter("query")]
-        public IDictionary<string, string?>? Query { get; set; }
+        public IDictionary<string, object?>? Query { get; set; }
     }
 }


### PR DESCRIPTION
Contributes to https://github.com/microsoft/kiota/issues/3800.