### PR TITLE
ci/dependabot coverage information

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -12,6 +12,8 @@ on:
 permissions:
   contents: read #those permissions are required to run the codeql analysis
   actions: read
+  code-quality: write
+  pull-requests: read
   security-events: write
 
 jobs:
@@ -46,5 +48,18 @@ jobs:
         run: dotnet test --solution ${{ env.solutionName }} --no-build --verbosity
           normal --framework net10.0 --results-directory TestResults --coverlet --coverlet-output-format
           opencover
+      - name: Install report generator
+        run: dotnet tool install --global dotnet-reportgenerator-globaltool
+      - name: Generate coverage report
+        run: reportgenerator "-reports:TestResults/coverage.opencover.*.xml" "-targetdir:.\reports\coverage" "-reporttypes:Html;MarkdownSummaryGithub;Cobertura"
+      - name: Add coverage to job summary
+        run: Get-Content .\reports\coverage\SummaryGithub.md >> $env:GITHUB_STEP_SUMMARY
+      - name: Upload coverage report
+        uses: actions/upload-code-coverage@d8e329117199404bba6fc81efe8093dc7c015e34 # v1.4.2
+        if: github.event_name != 'merge_group' && ((github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]') || (github.event_name != 'pull_request' && github.ref_name == github.event.repository.default_branch))
+        with:
+          file: .\reports\coverage\Cobertura.xml
+          language: CSharp
+          label: code-coverage/dotnet
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -44,7 +44,7 @@ jobs:
           normal --framework net472
       - name: Test for net10.0 and collect coverage
         run: dotnet test --solution ${{ env.solutionName }} --no-build --verbosity
-          normal --framework net10.0 -- --coverlet --coverlet-output-format
+          normal --framework net10.0 --results-directory TestResults --coverlet --coverlet-output-format
           opencover
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -64,8 +64,8 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         shell: pwsh
         run: |
-          dotnet tool run dotnet-sonarscanner begin /k:"microsoft_kiota-abstractions-dotnet" /o:"microsoft" /d:sonar.token="$env:SONAR_TOKEN" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.opencover.reportsPaths="tests/**/TestResults/coverage.opencover.*.xml"
+          dotnet tool run dotnet-sonarscanner begin /k:"microsoft_kiota-abstractions-dotnet" /o:"microsoft" /d:sonar.token="$env:SONAR_TOKEN" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.opencover.reportsPaths="TestResults/coverage.opencover.*.xml"
           dotnet workload restore
           dotnet build
-          dotnet test --solution Microsoft.Kiota.slnx --no-build --verbosity normal --framework net10.0 -- --coverlet --coverlet-output-format opencover
+          dotnet test --solution Microsoft.Kiota.slnx --no-build --verbosity normal --framework net10.0 --results-directory TestResults --coverlet --coverlet-output-format opencover
           dotnet tool run dotnet-sonarscanner end /d:sonar.token="$env:SONAR_TOKEN"


### PR DESCRIPTION
restores sonarqube coverage integration and adds the github one. Breakage most likely caused by #775