### PR TITLE
fix(http): handle not modified responses

### DIFF
--- a/src/http/httpClient/HttpClientRequestAdapter.cs
+++ b/src/http/httpClient/HttpClientRequestAdapter.cs
@@ -374,7 +374,12 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary
                 try
                 {
                     await ThrowIfFailedResponseAsync(response, errorMapping, span, cancellationToken).ConfigureAwait(false);
-                    if(shouldReturnNull(response)) return default;
+                    if(shouldReturnNull(response))
+                    {
+                        if(isStreamResponse)
+                            await DrainAsync(response, cancellationToken).ConfigureAwait(false);
+                        return default;
+                    }
                     if(isStreamResponse)
                     {
 #if NET5_0_OR_GREATER

--- a/src/http/httpClient/HttpClientRequestAdapter.cs
+++ b/src/http/httpClient/HttpClientRequestAdapter.cs
@@ -535,7 +535,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary
         }
         private static bool shouldReturnNull(HttpResponseMessage response)
         {
-            return response.StatusCode == HttpStatusCode.NoContent
+            return response.StatusCode is HttpStatusCode.NoContent or HttpStatusCode.NotModified
                    || response.Content == null
                    || response.Content.GetType().Name.Equals("EmptyContent", StringComparison.OrdinalIgnoreCase);// In NET 5 and above, Content is never null but represented by the internal class EmptyContent
                                                                                                                  // which MAY return instances of EmptyReadStream on reading(which is not seekable thus we can't read/get the length)
@@ -552,7 +552,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary
         private async Task ThrowIfFailedResponseAsync(HttpResponseMessage response, Dictionary<string, ParsableFactory<IParsable>>? errorMapping, Activity? activityForAttributes, CancellationToken cancellationToken)
         {
             using var span = activitySource?.StartActivity(nameof(ThrowIfFailedResponseAsync));
-            if(response.IsSuccessStatusCode || response.StatusCode is HttpStatusCode.Moved or HttpStatusCode.MovedPermanently or HttpStatusCode.Found or HttpStatusCode.Redirect) return;
+            if(response.IsSuccessStatusCode || response.StatusCode is HttpStatusCode.Moved or HttpStatusCode.MovedPermanently or HttpStatusCode.Found or HttpStatusCode.Redirect or HttpStatusCode.NotModified) return;
 
             activityForAttributes?.SetStatus(ActivityStatusCode.Error, "received_error_response");
 

--- a/tests/http/httpClient/RequestAdapterTests.cs
+++ b/tests/http/httpClient/RequestAdapterTests.cs
@@ -205,6 +205,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests
 
         [InlineData(HttpStatusCode.Redirect)]
         [InlineData(HttpStatusCode.MovedPermanently)]
+        [InlineData(HttpStatusCode.NotModified)]
         [Theory]
         public async Task SendMethodDoesNotThrowOn3XXWithNoLocationAsync(HttpStatusCode httpStatusCode)
         {
@@ -270,6 +271,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests
         [InlineData(HttpStatusCode.Accepted)]
         [InlineData(HttpStatusCode.NonAuthoritativeInformation)]
         [InlineData(HttpStatusCode.NoContent)]
+        [InlineData(HttpStatusCode.NotModified)]
         [Theory]
         public async Task SendStreamReturnsNullForNoContent(HttpStatusCode statusCode)
         {
@@ -298,6 +300,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests
         [InlineData(HttpStatusCode.NonAuthoritativeInformation)]
         [InlineData(HttpStatusCode.NoContent)]
         [InlineData(HttpStatusCode.PartialContent)]
+        [InlineData(HttpStatusCode.NotModified)]
         [Theory]
         public async Task SendSNoContentDoesntFailOnOtherStatusCodes(HttpStatusCode statusCode)
         {
@@ -324,6 +327,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests
         [InlineData(HttpStatusCode.NonAuthoritativeInformation)]
         [InlineData(HttpStatusCode.NoContent)]
         [InlineData(HttpStatusCode.ResetContent)]
+        [InlineData(HttpStatusCode.NotModified)]
         [Theory]
         public async Task SendReturnsNullOnNoContent(HttpStatusCode statusCode)
         {
@@ -353,6 +357,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests
         [InlineData(HttpStatusCode.NonAuthoritativeInformation)]
         [InlineData(HttpStatusCode.NoContent)]
         [InlineData(HttpStatusCode.ResetContent)]
+        [InlineData(HttpStatusCode.NotModified)]
         [Theory]
         public async Task SendReturnsNullOnNoContentWithContentHeaderPresent(HttpStatusCode statusCode)
         {

--- a/tests/http/httpClient/RequestAdapterTests.cs
+++ b/tests/http/httpClient/RequestAdapterTests.cs
@@ -294,6 +294,31 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests
 
             Assert.Null(response);
         }
+        [Fact]
+        public async Task SendStreamDisposesNotModifiedResponse()
+        {
+            var mockHandler = new Mock<HttpMessageHandler>();
+            var content = new DisposableContent(new byte[] { 1, 2, 3 });
+            var client = new HttpClient(mockHandler.Object);
+            mockHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.NotModified,
+                Content = content,
+            });
+            var adapter = new HttpClientRequestAdapter(_authenticationProvider, httpClient: client);
+            var requestInfo = new RequestInformation
+            {
+                HttpMethod = Method.GET,
+                UrlTemplate = "https://example.com"
+            };
+
+            var response = await adapter.SendPrimitiveAsync<Stream>(requestInfo, cancellationToken: TestContext.Current.CancellationToken);
+
+            Assert.Null(response);
+            Assert.True(content.IsDisposed);
+        }
         [InlineData(HttpStatusCode.OK)]
         [InlineData(HttpStatusCode.Created)]
         [InlineData(HttpStatusCode.Accepted)]
@@ -302,7 +327,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests
         [InlineData(HttpStatusCode.PartialContent)]
         [InlineData(HttpStatusCode.NotModified)]
         [Theory]
-        public async Task SendSNoContentDoesntFailOnOtherStatusCodes(HttpStatusCode statusCode)
+        public async Task SendNoContentDoesntFailOnOtherStatusCodes(HttpStatusCode statusCode)
         {
             var mockHandler = new Mock<HttpMessageHandler>();
             var client = new HttpClient(mockHandler.Object);
@@ -1212,6 +1237,21 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests
             Assert.NotNull(adapter2);
             Assert.NotNull(adapter1.SerializationWriterFactory);
             Assert.NotNull(adapter2.SerializationWriterFactory);
+        }
+
+        private sealed class DisposableContent : ByteArrayContent
+        {
+            public DisposableContent(byte[] content) : base(content)
+            {
+            }
+
+            public bool IsDisposed { get; private set; }
+
+            protected override void Dispose(bool disposing)
+            {
+                IsDisposed = disposing;
+                base.Dispose(disposing);
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

- Treat HTTP 304 Not Modified as a valid response instead of an API error.
- Return `null` for its body across model, primitive stream, and no-content send paths.
- Extend the existing response-status theories with 304 regression coverage.

Fixes #531

## Validation

- HTTP client test suite on .NET 10: 329 passed
- HTTP client test suite on .NET 8: 329 passed
- HTTP client test suite on .NET Framework 4.7.2: 328 passed
- Targeted response-status cases: 30 passed
- `dotnet format --verify-no-changes` for source and test projects
- `git diff --check`

The new 304 case was also verified to fail with `ApiException` when the production change was temporarily reverted.
