### PR TITLE
ci: migrate MTP reporting

### DIFF
--- a/.azure-pipelines/ci-build.yml
+++ b/.azure-pipelines/ci-build.yml
@@ -105,7 +105,7 @@ extends:
               # Run the Unit test
               - pwsh: dotnet test --solution $(Build.SourcesDirectory)\Microsoft.Kiota.slnx
                   --configuration $(BuildConfiguration) --no-build --framework
-                  net10.0
+                  net10.0 --report-azdo --publish-azdo-test-results
                 displayName: "Test projects in Microsoft.Kiota"
 
               - task: EsrpCodeSigning@6

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,12 +9,12 @@ updates:
     labels:
       - dependencies
     groups:
-      xunit:
+      testing-dependencies:
         patterns:
-          - xunit*
-      coverlet:
-        patterns:
-          - coverlet*
+          - coverlet.*
+          - Microsoft.NET.Test.Sdk
+          - Microsoft.Testing.*
+          - xunit.*
     cooldown:
       default-days: 7
   - package-ecosystem: github-actions

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -43,15 +43,15 @@ jobs:
           /p:UseSharedCompilation=false
       - name: Test for net472
         run: dotnet test --solution ${{ env.solutionName }} --no-build --verbosity
-          normal --framework net472
+          normal --framework net472 --report-gh
       - name: Test for net10.0 and collect coverage
         run: dotnet test --solution ${{ env.solutionName }} --no-build --verbosity
-          normal --framework net10.0 --results-directory TestResults --coverlet --coverlet-output-format
-          opencover
+          normal --framework net10.0 --results-directory=./TestResults --coverlet --coverlet-output-format
+          cobertura --report-gh
       - name: Install report generator
         run: dotnet tool install --global dotnet-reportgenerator-globaltool
       - name: Generate coverage report
-        run: reportgenerator "-reports:TestResults/coverage.opencover.*.xml" "-targetdir:.\reports\coverage" "-reporttypes:Html;MarkdownSummaryGithub;Cobertura"
+        run: reportgenerator "-reports:TestResults/coverage.cobertura.*.xml" "-targetdir:.\reports\coverage" "-reporttypes:Html;MarkdownSummaryGithub;Cobertura"
       - name: Add coverage to job summary
         run: Get-Content .\reports\coverage\SummaryGithub.md >> $env:GITHUB_STEP_SUMMARY
       - name: Upload coverage report

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -67,5 +67,5 @@ jobs:
           dotnet tool run dotnet-sonarscanner begin /k:"microsoft_kiota-abstractions-dotnet" /o:"microsoft" /d:sonar.token="$env:SONAR_TOKEN" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.opencover.reportsPaths="TestResults/coverage.opencover.*.xml"
           dotnet workload restore
           dotnet build
-          dotnet test --solution Microsoft.Kiota.slnx --no-build --verbosity normal --framework net10.0 --results-directory TestResults --coverlet --coverlet-output-format opencover
+          dotnet test --solution Microsoft.Kiota.slnx --no-build --verbosity normal --framework net10.0 --results-directory=./TestResults --coverlet --coverlet-output-format opencover --report-gh
           dotnet tool run dotnet-sonarscanner end /d:sonar.token="$env:SONAR_TOKEN"

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -19,8 +19,10 @@
     <PackageVersion Include="coverlet.MTP" Version="10.0.1" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.11" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.11" />
-    <PackageVersion Include="Microsoft.Testing.Extensions.Telemetry" Version="2.3.3" />
-    <PackageVersion Include="Microsoft.Testing.Platform" Version="2.3.3" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.AzureDevOpsReport" Version="2.4.0" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.GitHubActionsReport" Version="2.4.0" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.Telemetry" Version="2.4.0" />
+    <PackageVersion Include="Microsoft.Testing.Platform" Version="2.4.0" />
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="xunit.v3.mtp-v2" Version="4.0.0" />
   </ItemGroup>

--- a/tests/abstractions/Microsoft.Kiota.Abstractions.Tests.csproj
+++ b/tests/abstractions/Microsoft.Kiota.Abstractions.Tests.csproj
@@ -5,6 +5,8 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Testing.Platform" />
+    <PackageReference Include="Microsoft.Testing.Extensions.AzureDevOpsReport" />
+    <PackageReference Include="Microsoft.Testing.Extensions.GitHubActionsReport" />
     <PackageReference Include="Moq" />
     <PackageReference Include="xunit.v3.mtp-v2" />
   </ItemGroup>

--- a/tests/authentication/azure/Microsoft.Kiota.Authentication.Azure.Tests.csproj
+++ b/tests/authentication/azure/Microsoft.Kiota.Authentication.Azure.Tests.csproj
@@ -5,6 +5,8 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Testing.Platform" />
+    <PackageReference Include="Microsoft.Testing.Extensions.AzureDevOpsReport" />
+    <PackageReference Include="Microsoft.Testing.Extensions.GitHubActionsReport" />
     <PackageReference Include="Moq" />
     <PackageReference Include="xunit.v3.mtp-v2" />
   </ItemGroup>

--- a/tests/bundle/Microsoft.Kiota.Bundle.Tests.csproj
+++ b/tests/bundle/Microsoft.Kiota.Bundle.Tests.csproj
@@ -5,6 +5,8 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Testing.Platform" />
+    <PackageReference Include="Microsoft.Testing.Extensions.AzureDevOpsReport" />
+    <PackageReference Include="Microsoft.Testing.Extensions.GitHubActionsReport" />
     <PackageReference Include="Moq" />
     <PackageReference Include="xunit.v3.mtp-v2" />
   </ItemGroup>

--- a/tests/http/httpClient/Microsoft.Kiota.Http.HttpClientLibrary.Tests.csproj
+++ b/tests/http/httpClient/Microsoft.Kiota.Http.HttpClientLibrary.Tests.csproj
@@ -5,6 +5,8 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Testing.Platform" />
+    <PackageReference Include="Microsoft.Testing.Extensions.AzureDevOpsReport" />
+    <PackageReference Include="Microsoft.Testing.Extensions.GitHubActionsReport" />
     <PackageReference Include="Moq" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Microsoft.Extensions.Http" />

--- a/tests/serialization/form/Microsoft.Kiota.Serialization.Form.Tests.csproj
+++ b/tests/serialization/form/Microsoft.Kiota.Serialization.Form.Tests.csproj
@@ -5,6 +5,8 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Testing.Platform" />
+    <PackageReference Include="Microsoft.Testing.Extensions.AzureDevOpsReport" />
+    <PackageReference Include="Microsoft.Testing.Extensions.GitHubActionsReport" />
     <PackageReference Include="Moq" />
     <PackageReference Include="xunit.v3.mtp-v2" />
   </ItemGroup>

--- a/tests/serialization/json/Microsoft.Kiota.Serialization.Json.Tests.csproj
+++ b/tests/serialization/json/Microsoft.Kiota.Serialization.Json.Tests.csproj
@@ -5,6 +5,8 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Testing.Platform" />
+    <PackageReference Include="Microsoft.Testing.Extensions.AzureDevOpsReport" />
+    <PackageReference Include="Microsoft.Testing.Extensions.GitHubActionsReport" />
     <PackageReference Include="Moq" />
     <PackageReference Include="xunit.v3.mtp-v2" />
   </ItemGroup>

--- a/tests/serialization/multipart/Microsoft.Kiota.Serialization.Multipart.Tests.csproj
+++ b/tests/serialization/multipart/Microsoft.Kiota.Serialization.Multipart.Tests.csproj
@@ -5,6 +5,8 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Testing.Platform" />
+    <PackageReference Include="Microsoft.Testing.Extensions.AzureDevOpsReport" />
+    <PackageReference Include="Microsoft.Testing.Extensions.GitHubActionsReport" />
     <PackageReference Include="Moq" />
     <PackageReference Include="xunit.v3.mtp-v2" />
   </ItemGroup>

--- a/tests/serialization/text/Microsoft.Kiota.Serialization.Text.Tests.csproj
+++ b/tests/serialization/text/Microsoft.Kiota.Serialization.Text.Tests.csproj
@@ -5,6 +5,8 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Testing.Platform" />
+    <PackageReference Include="Microsoft.Testing.Extensions.AzureDevOpsReport" />
+    <PackageReference Include="Microsoft.Testing.Extensions.GitHubActionsReport" />
     <PackageReference Include="Moq" />
     <PackageReference Include="xunit.v3.mtp-v2" />
   </ItemGroup>


### PR DESCRIPTION
Ports the Microsoft Testing Platform reporting updates from microsoft/kiota.\n\n- Enables GitHub Actions and Azure DevOps MTP reporters for dotnet test.\n- Adds the reporter extension packages and aligns MTP package versions.\n- Updates coverlet.MTP coverage arguments/globs and Dependabot testing dependency grouping.\n\nValidation:\n- dotnet restore D:\\github\\kiota-dotnet\\Microsoft.Kiota.slnx --verbosity minimal\n- dotnet test D:\\github\\kiota-dotnet\\tests\\abstractions\\Microsoft.Kiota.Abstractions.Tests.csproj --framework net10.0 --no-restore --verbosity minimal --report-gh\n- dotnet test D:\\github\\kiota-dotnet\\tests\\abstractions\\Microsoft.Kiota.Abstractions.Tests.csproj --framework net10.0 --no-restore --no-build --verbosity minimal --report-azdo --publish-azdo-test-results\n- dotnet test tests\\abstractions\\Microsoft.Kiota.Abstractions.Tests.csproj --framework net10.0 --no-restore --no-build --verbosity minimal --results-directory=./TestResults --coverlet --coverlet-output-format cobertura --report-gh