### PR TITLE
tests/missing cancellation tokens

### DIFF
--- a/src/http/httpClient/Middleware/BodyInspectionHandler.cs
+++ b/src/http/httpClient/Middleware/BodyInspectionHandler.cs
@@ -91,7 +91,11 @@ public class BodyInspectionHandler : DelegatingHandler
             }
 
             var stream = new MemoryStream();
+#if NET10_0_OR_GREATER
+            await httpContent.LoadIntoBufferAsync(cancellationToken).ConfigureAwait(false);
+#else
             await httpContent.LoadIntoBufferAsync().ConfigureAwait(false);
+#endif
 
 #if NET5_0_OR_GREATER
             await httpContent.CopyToAsync(stream, cancellationToken).ConfigureAwait(false);

--- a/src/http/httpClient/Middleware/RetryHandler.cs
+++ b/src/http/httpClient/Middleware/RetryHandler.cs
@@ -103,7 +103,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Middleware
 
             while(retryCount < retryOption.MaxRetry)
             {
-                exceptions.Add(await GetInnerExceptionAsync(response).ConfigureAwait(false));
+                exceptions.Add(await GetInnerExceptionAsync(response, cancellationToken).ConfigureAwait(false));
                 using var retryActivity = activitySource?.StartActivity($"{nameof(RetryHandler)}_{nameof(SendAsync)} - attempt {retryCount}");
                 retryActivity?.SetTag(HttpClientRequestAdapter.RetryCountAttributeName, retryCount);
                 retryActivity?.SetTag("http.response.status_code", response.StatusCode);
@@ -149,7 +149,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Middleware
                 }
             }
 
-            exceptions.Add(await GetInnerExceptionAsync(response).ConfigureAwait(false));
+            exceptions.Add(await GetInnerExceptionAsync(response, cancellationToken).ConfigureAwait(false));
 
             throw new AggregateException($"Too many retries performed. More than {retryCount} retries encountered while sending the request.", exceptions);
         }
@@ -217,7 +217,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Middleware
             return Math.Pow(2, retryCount) * delay;
         }
 
-        private static async Task<Exception> GetInnerExceptionAsync(HttpResponseMessage response)
+        private static async Task<Exception> GetInnerExceptionAsync(HttpResponseMessage response, CancellationToken cancellationToken)
         {
             string? errorMessage = null;
 
@@ -225,7 +225,11 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Middleware
             // before retry attempt and before the TooManyRetries ServiceException.
             if(response.Content != null)
             {
+#if NET5_0_OR_GREATER
+                errorMessage = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+#else
                 errorMessage = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+#endif
             }
 
             var headersDictionary = new Dictionary<string, IEnumerable<string>>();

--- a/src/serialization/text/TextParseNodeFactory.cs
+++ b/src/serialization/text/TextParseNodeFactory.cs
@@ -24,7 +24,11 @@ public class TextParseNodeFactory : IParseNodeFactory
         _ = content ?? throw new ArgumentNullException(nameof(content));
 
         using var reader = new StreamReader(content);
+#if NET7_0_OR_GREATER
+        var stringContent = await reader.ReadToEndAsync(cancellationToken).ConfigureAwait(false);
+#else
         var stringContent = await reader.ReadToEndAsync().ConfigureAwait(false);
+#endif
         return new TextParseNode(stringContent);
     }
 }

--- a/tests/http/httpClient/Middleware/AuthorizationHandlerTests.cs
+++ b/tests/http/httpClient/Middleware/AuthorizationHandlerTests.cs
@@ -74,7 +74,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests.Middleware
             HttpResponseMessage httpResponse = new HttpResponseMessage(HttpStatusCode.OK);
             this._testHttpMessageHandler.SetHttpResponse(httpResponse);// set the mock response
             // Act
-            HttpResponseMessage response = await this._invoker.SendAsync(httpRequestMessage, new CancellationToken());
+            HttpResponseMessage response = await this._invoker.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
             // Assert
             Assert.NotNull(response.RequestMessage);
             Assert.True(response.RequestMessage.Headers.Contains("Authorization"));
@@ -93,7 +93,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests.Middleware
             this._testHttpMessageHandler.SetHttpResponse(httpResponse);// set the mock response
 
             // Act
-            HttpResponseMessage response = await this._invoker.SendAsync(httpRequestMessage, new CancellationToken());
+            HttpResponseMessage response = await this._invoker.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.NotNull(response.RequestMessage);
@@ -113,7 +113,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests.Middleware
             this._testHttpMessageHandler.SetHttpResponse(httpResponse);// set the mock response
 
             // Act
-            HttpResponseMessage response = await this._invoker.SendAsync(httpRequestMessage, new CancellationToken());
+            HttpResponseMessage response = await this._invoker.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.NotNull(response.RequestMessage);
@@ -133,7 +133,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests.Middleware
             this._testHttpMessageHandler.SetHttpResponse(httpResponse, new HttpResponseMessage(HttpStatusCode.OK));// set the mock response
 
             // Act
-            HttpResponseMessage response = await this._invoker.SendAsync(httpRequestMessage, new CancellationToken());
+            HttpResponseMessage response = await this._invoker.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.NotNull(response.RequestMessage);
@@ -160,7 +160,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests.Middleware
             this._testHttpMessageHandler.SetHttpResponse(httpResponse, new HttpResponseMessage(HttpStatusCode.OK));// set the mock response
 
             // Act
-            HttpResponseMessage response = await this._invoker.SendAsync(httpRequestMessage, new CancellationToken());
+            HttpResponseMessage response = await this._invoker.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);

--- a/tests/http/httpClient/Middleware/ChaosHandlerTests.cs
+++ b/tests/http/httpClient/Middleware/ChaosHandlerTests.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests.Middleware
             // Make calls until all known failures have been triggered
             while(responses.Count < 3)
             {
-                var response = await invoker.SendAsync(request, new CancellationToken());
+                var response = await invoker.SendAsync(request, TestContext.Current.CancellationToken);
                 if(response.StatusCode != HttpStatusCode.OK)
                 {
                     responses[response.StatusCode] = null;
@@ -72,7 +72,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests.Middleware
             // Make calls until all known failures have been triggered
             while(responses.Count < 5)
             {
-                var response = await invoker.SendAsync(request, new CancellationToken());
+                var response = await invoker.SendAsync(request, TestContext.Current.CancellationToken);
                 if(response.StatusCode != HttpStatusCode.OK)
                 {
                     responses[response.StatusCode] = null;
@@ -115,13 +115,13 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests.Middleware
             {
                 RequestUri = new Uri("http://example.org/success")
             };
-            var response1 = await new HttpMessageInvoker(handler).SendAsync(request1, new CancellationToken());
+            var response1 = await new HttpMessageInvoker(handler).SendAsync(request1, TestContext.Current.CancellationToken);
 
             var request2 = new HttpRequestMessage
             {
                 RequestUri = new Uri("http://example.org/fail")
             };
-            var response2 = await new HttpMessageInvoker(handler).SendAsync(request2, new CancellationToken());
+            var response2 = await new HttpMessageInvoker(handler).SendAsync(request2, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, response1.StatusCode);

--- a/tests/http/httpClient/Middleware/ChaosHandlerTests.cs
+++ b/tests/http/httpClient/Middleware/ChaosHandlerTests.cs
@@ -111,17 +111,18 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests.Middleware
             };
 
             // Act
+            using var invoker = new HttpMessageInvoker(handler);
             var request1 = new HttpRequestMessage
             {
                 RequestUri = new Uri("http://example.org/success")
             };
-            var response1 = await new HttpMessageInvoker(handler).SendAsync(request1, TestContext.Current.CancellationToken);
+            var response1 = await invoker.SendAsync(request1, TestContext.Current.CancellationToken);
 
             var request2 = new HttpRequestMessage
             {
                 RequestUri = new Uri("http://example.org/fail")
             };
-            var response2 = await new HttpMessageInvoker(handler).SendAsync(request2, TestContext.Current.CancellationToken);
+            var response2 = await invoker.SendAsync(request2, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, response1.StatusCode);

--- a/tests/http/httpClient/Middleware/CompressionHandlerTests.cs
+++ b/tests/http/httpClient/Middleware/CompressionHandlerTests.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests.Middleware
             HttpResponseMessage httpResponse = new HttpResponseMessage(HttpStatusCode.OK);
             this._testHttpMessageHandler.SetHttpResponse(httpResponse);// set the mock response
             // Act
-            HttpResponseMessage response = await this._invoker.SendAsync(httpRequestMessage, new CancellationToken());
+            HttpResponseMessage response = await this._invoker.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
             // Assert
             Assert.Same(httpRequestMessage, response.RequestMessage);
             Assert.NotNull(response.RequestMessage);
@@ -71,7 +71,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests.Middleware
             httpResponse.Content.Headers.ContentEncoding.Add(CompressionHandler.GZip);
             this._testHttpMessageHandler.SetHttpResponse(httpResponse);// set the mock response
             // Act
-            HttpResponseMessage decompressedResponse = await this._invoker.SendAsync(httpRequestMessage, new CancellationToken());
+            HttpResponseMessage decompressedResponse = await this._invoker.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
             string responseContentString = await decompressedResponse.Content.ReadAsStringAsync(
 #if NET5_0_OR_GREATER
                 TestContext.Current.CancellationToken
@@ -95,7 +95,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests.Middleware
             };
             this._testHttpMessageHandler.SetHttpResponse(httpResponse);// set the mock response
             // Act
-            HttpResponseMessage compressedResponse = await this._invoker.SendAsync(httpRequestMessage, new CancellationToken());
+            HttpResponseMessage compressedResponse = await this._invoker.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
             string responseContentString = await compressedResponse.Content.ReadAsStringAsync(
 #if NET5_0_OR_GREATER
                 TestContext.Current.CancellationToken
@@ -128,7 +128,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests.Middleware
 
             this._testHttpMessageHandler.SetHttpResponse(httpResponse);// set the mock response
             // Arrange
-            HttpResponseMessage compressedResponse = await this._invoker.SendAsync(httpRequestMessage, new CancellationToken());
+            HttpResponseMessage compressedResponse = await this._invoker.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
             string decompressedResponseString = await compressedResponse.Content.ReadAsStringAsync(
 #if NET5_0_OR_GREATER
                 TestContext.Current.CancellationToken

--- a/tests/http/httpClient/Middleware/ParametersNameDecodingHandlerTests.cs
+++ b/tests/http/httpClient/Middleware/ParametersNameDecodingHandlerTests.cs
@@ -47,7 +47,7 @@ public class ParametersDecodingHandlerTests
         Assert.NotNull(requestMessage);
 
         // Act
-        await _invoker.SendAsync(requestMessage, new CancellationToken());
+        await _invoker.SendAsync(requestMessage, TestContext.Current.CancellationToken);
 
         // Assert the request stays the same
         Assert.Equal(result, requestMessage.RequestUri!.ToString());
@@ -87,7 +87,7 @@ public class ParametersDecodingHandlerTests
         Assert.NotNull(requestMessage);
 
         // Act
-        await _invoker.SendAsync(requestMessage, new CancellationToken());
+        await _invoker.SendAsync(requestMessage, TestContext.Current.CancellationToken);
 
         // Assert the request stays the same
         Assert.Equal(result, requestMessage.RequestUri!.ToString());

--- a/tests/http/httpClient/Middleware/RedirectHandlerTests.cs
+++ b/tests/http/httpClient/Middleware/RedirectHandlerTests.cs
@@ -134,7 +134,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests.Middleware
                 var redirectResponse = new HttpResponseMessage(HttpStatusCode.OK);
                 this._testHttpMessageHandler.SetHttpResponse(redirectResponse); // sets the mock response
                 // Act
-                var response = await this._invoker.SendAsync(httpRequestMessage, new CancellationToken());
+                var response = await this._invoker.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
                 // Assert
                 Assert.Equal(HttpStatusCode.OK, response.StatusCode);
                 Assert.Same(response.RequestMessage, httpRequestMessage);
@@ -157,7 +157,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests.Middleware
                 redirectResponse.Headers.Location = new Uri("http://example.org/bar");
                 this._testHttpMessageHandler.SetHttpResponse(redirectResponse, new HttpResponseMessage(HttpStatusCode.OK));// sets the mock response
                 // Act
-                var response = await _invoker.SendAsync(httpRequestMessage, new CancellationToken());
+                var response = await _invoker.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
                 // Assert
                 Assert.Equal(response.RequestMessage?.Method, httpRequestMessage.Method);
                 Assert.NotSame(response.RequestMessage, httpRequestMessage);
@@ -183,7 +183,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests.Middleware
                 redirectResponse.Headers.Location = new Uri("http://example.org/bar");
                 this._testHttpMessageHandler.SetHttpResponse(redirectResponse, new HttpResponseMessage(HttpStatusCode.OK));// sets the mock response
                 // Act
-                var response = await _invoker.SendAsync(httpRequestMessage, new CancellationToken());
+                var response = await _invoker.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
                 // Assert
                 Assert.NotEqual(response.RequestMessage?.Method, httpRequestMessage.Method);
                 Assert.Equal(response.RequestMessage?.Method, HttpMethod.Get);
@@ -207,7 +207,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests.Middleware
                 redirectResponse.Headers.Location = new Uri("http://example.net/bar");
                 this._testHttpMessageHandler.SetHttpResponse(redirectResponse, new HttpResponseMessage(HttpStatusCode.OK));// sets the mock response
                 // Act
-                var response = await _invoker.SendAsync(httpRequestMessage, new CancellationToken());
+                var response = await _invoker.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
                 // Assert
                 Assert.NotSame(response.RequestMessage, httpRequestMessage);
                 Assert.NotSame(response.RequestMessage?.RequestUri?.Host, httpRequestMessage.RequestUri?.Host);
@@ -231,7 +231,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests.Middleware
                 redirectResponse.Headers.Location = new Uri("http://example.org/bar");
                 this._testHttpMessageHandler.SetHttpResponse(redirectResponse, new HttpResponseMessage(HttpStatusCode.OK));// sets the mock response
                 // Act
-                var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => this._invoker.SendAsync(httpRequestMessage, CancellationToken.None));
+                var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => this._invoker.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken));
                 // Assert
                 Assert.Contains("Redirects with changing schemes not allowed by default", exception.Message);
                 Assert.Equal("Scheme changed from https to http.", exception.InnerException?.Message);
@@ -255,7 +255,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests.Middleware
                 this._redirectHandler.RedirectOption.AllowRedirectOnSchemeChange = true;// Enable redirects on scheme change
                 this._testHttpMessageHandler.SetHttpResponse(redirectResponse, new HttpResponseMessage(HttpStatusCode.OK));// sets the mock response
                 // Act
-                var response = await _invoker.SendAsync(httpRequestMessage, new CancellationToken());
+                var response = await _invoker.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
                 // Assert
                 Assert.NotSame(response.RequestMessage, httpRequestMessage);
                 Assert.NotSame(response.RequestMessage?.RequestUri?.Scheme, httpRequestMessage.RequestUri?.Scheme);
@@ -274,7 +274,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests.Middleware
                 redirectResponse.Headers.Location = new Uri("http://example.org/bar");
                 this._testHttpMessageHandler.SetHttpResponse(redirectResponse, new HttpResponseMessage(HttpStatusCode.OK));// sets the mock response
                 // Act
-                var response = await _invoker.SendAsync(httpRequestMessage, new CancellationToken());
+                var response = await _invoker.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
                 // Assert
                 Assert.NotSame(response.RequestMessage, httpRequestMessage);
                 Assert.Equal(response.RequestMessage?.RequestUri?.Host, httpRequestMessage.RequestUri?.Host);
@@ -297,7 +297,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests.Middleware
                 redirectResponse.Headers.Location = new Uri("http://example.org:9090/bar");
                 this._testHttpMessageHandler.SetHttpResponse(redirectResponse, new HttpResponseMessage(HttpStatusCode.OK));// sets the mock response
                 // Act
-                var response = await _invoker.SendAsync(httpRequestMessage, new CancellationToken());
+                var response = await _invoker.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
                 // Assert
                 Assert.NotSame(response.RequestMessage, httpRequestMessage);
                 Assert.Equal(response.RequestMessage?.RequestUri?.Host, httpRequestMessage.RequestUri?.Host);
@@ -321,7 +321,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests.Middleware
                 redirectResponse.Headers.Location = new Uri("http://example.org:9090/bar");
                 this._testHttpMessageHandler.SetHttpResponse(redirectResponse, new HttpResponseMessage(HttpStatusCode.OK));// sets the mock response
                 // Act
-                var response = await _invoker.SendAsync(httpRequestMessage, new CancellationToken());
+                var response = await _invoker.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
                 // Assert
                 Assert.NotSame(response.RequestMessage, httpRequestMessage);
                 Assert.Equal(response.RequestMessage?.RequestUri?.Host, httpRequestMessage.RequestUri?.Host);
@@ -341,7 +341,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests.Middleware
                 redirectResponse.Headers.Location = new Uri("http://example.org:8080/bar");
                 this._testHttpMessageHandler.SetHttpResponse(redirectResponse, new HttpResponseMessage(HttpStatusCode.OK));// sets the mock response
                 // Act
-                var response = await _invoker.SendAsync(httpRequestMessage, new CancellationToken());
+                var response = await _invoker.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
                 // Assert
                 Assert.NotSame(response.RequestMessage, httpRequestMessage);
                 Assert.Equal(response.RequestMessage?.RequestUri?.Host, httpRequestMessage.RequestUri?.Host);
@@ -359,7 +359,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests.Middleware
                 redirectResponse.Headers.Location = new Uri("/bar", UriKind.Relative);
                 this._testHttpMessageHandler.SetHttpResponse(redirectResponse, new HttpResponseMessage(HttpStatusCode.OK));// sets the mock response
                 // Act
-                var response = await _invoker.SendAsync(httpRequestMessage, new CancellationToken());
+                var response = await _invoker.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
                 // Assert
                 Assert.NotSame(response.RequestMessage, httpRequestMessage);
                 Assert.Equal("http://example.org/bar", response.RequestMessage?.RequestUri?.AbsoluteUri);
@@ -379,7 +379,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests.Middleware
                 this._testHttpMessageHandler.SetHttpResponse(response1, response2);// sets the mock response
                 // Act
                 var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => this._invoker.SendAsync(
-                   httpRequestMessage, CancellationToken.None));
+                   httpRequestMessage, TestContext.Current.CancellationToken));
                 // Assert
                 Assert.Equal("Too many redirects performed", exception.Message);
                 Assert.Equal("Max redirects exceeded. Redirect count : 5", exception.InnerException?.Message);
@@ -402,7 +402,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests.Middleware
                 redirectResponse.Headers.Location = new Uri("http://example.net/bar");
                 this._testHttpMessageHandler.SetHttpResponse(redirectResponse, new HttpResponseMessage(HttpStatusCode.OK));// sets the mock response
                 // Act
-                var response = await _invoker.SendAsync(httpRequestMessage, new CancellationToken());
+                var response = await _invoker.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
                 // Assert - ProxyAuthorization is removed when no proxy is configured
                 Assert.NotSame(response.RequestMessage, httpRequestMessage);
                 Assert.NotSame(response.RequestMessage?.RequestUri?.Host, httpRequestMessage.RequestUri?.Host);
@@ -425,7 +425,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests.Middleware
                 redirectResponse.Headers.Location = new Uri("http://example.net/bar");
                 this._testHttpMessageHandler.SetHttpResponse(redirectResponse, new HttpResponseMessage(HttpStatusCode.OK));// sets the mock response
                 // Act
-                var response = await _invoker.SendAsync(httpRequestMessage, new CancellationToken());
+                var response = await _invoker.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
                 // Assert
                 Assert.NotSame(response.RequestMessage, httpRequestMessage);
                 Assert.NotSame(response.RequestMessage?.RequestUri?.Host, httpRequestMessage.RequestUri?.Host);
@@ -475,7 +475,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests.Middleware
             mockHandler.SetHttpResponse(redirectResponse, new HttpResponseMessage(HttpStatusCode.OK));
 
             // Act
-            var response = await invoker.SendAsync(httpRequestMessage, CancellationToken.None);
+            var response = await invoker.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
 
             // Assert - Custom headers should be removed, but non-sensitive should remain
             Assert.NotSame(response.RequestMessage, httpRequestMessage);
@@ -522,7 +522,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests.Middleware
             mockHandler.SetHttpResponse(redirectResponse, new HttpResponseMessage(HttpStatusCode.OK));
 
             // Act
-            var response = await invoker.SendAsync(httpRequestMessage, CancellationToken.None);
+            var response = await invoker.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
 
             // Assert - Custom headers should be removed on scheme change
             Assert.NotSame(response.RequestMessage, httpRequestMessage);
@@ -562,7 +562,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests.Middleware
             mockHandler.SetHttpResponse(redirectResponse, new HttpResponseMessage(HttpStatusCode.OK));
 
             // Act
-            var response = await invoker.SendAsync(httpRequestMessage, CancellationToken.None);
+            var response = await invoker.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
 
             // Assert - Custom headers should be kept when host and scheme are the same
             Assert.NotSame(response.RequestMessage, httpRequestMessage);
@@ -592,7 +592,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests.Middleware
             mockHandler.SetHttpResponse(redirectResponse, new HttpResponseMessage(HttpStatusCode.OK));
 
             // Act
-            var response = await invoker.SendAsync(httpRequestMessage, CancellationToken.None);
+            var response = await invoker.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
 
             // Assert - Default behavior should remove Authorization on host change
             Assert.Null(response.RequestMessage?.Headers.Authorization);
@@ -645,7 +645,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests.Middleware
             mockHandler.SetHttpResponse(redirectResponse, new HttpResponseMessage(HttpStatusCode.OK));
 
             // Act
-            var response = await invoker.SendAsync(httpRequestMessage, CancellationToken.None);
+            var response = await invoker.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
 
             // Assert - X-Api-Key should be kept because proxy is active
             Assert.NotSame(response.RequestMessage, httpRequestMessage);
@@ -669,7 +669,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests.Middleware
                 this._redirectHandler.RedirectOption.AllowRedirectOnSchemeChange = true;// Enable redirects on scheme change
                 this._testHttpMessageHandler.SetHttpResponse(redirectResponse, new HttpResponseMessage(HttpStatusCode.OK));// sets the mock response
                 // Act
-                var response = await _invoker.SendAsync(httpRequestMessage, new CancellationToken());
+                var response = await _invoker.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
                 // Assert - ProxyAuthorization is removed when no proxy is configured
                 Assert.NotSame(response.RequestMessage, httpRequestMessage);
                 Assert.NotSame(response.RequestMessage?.RequestUri?.Scheme, httpRequestMessage.RequestUri?.Scheme);
@@ -693,7 +693,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests.Middleware
                 this._redirectHandler.RedirectOption.AllowRedirectOnSchemeChange = true;// Enable redirects on scheme change
                 this._testHttpMessageHandler.SetHttpResponse(redirectResponse, new HttpResponseMessage(HttpStatusCode.OK));// sets the mock response
                 // Act
-                var response = await _invoker.SendAsync(httpRequestMessage, new CancellationToken());
+                var response = await _invoker.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
                 // Assert
                 Assert.NotSame(response.RequestMessage, httpRequestMessage);
                 Assert.NotSame(response.RequestMessage?.RequestUri?.Scheme, httpRequestMessage.RequestUri?.Scheme);
@@ -712,7 +712,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests.Middleware
                 redirectResponse.Headers.Location = new Uri("http://example.org/bar");
                 this._testHttpMessageHandler.SetHttpResponse(redirectResponse, new HttpResponseMessage(HttpStatusCode.OK));// sets the mock response
                 // Act
-                var response = await _invoker.SendAsync(httpRequestMessage, new CancellationToken());
+                var response = await _invoker.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
                 // Assert - ProxyAuthorization is removed when no proxy is configured
                 Assert.NotSame(response.RequestMessage, httpRequestMessage);
                 Assert.Equal(response.RequestMessage?.RequestUri?.Host, httpRequestMessage.RequestUri?.Host);
@@ -731,7 +731,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests.Middleware
                 redirectResponse.Headers.Location = new Uri("http://example.org/bar");
                 this._testHttpMessageHandler.SetHttpResponse(redirectResponse, new HttpResponseMessage(HttpStatusCode.OK));// sets the mock response
                 // Act
-                var response = await _invoker.SendAsync(httpRequestMessage, new CancellationToken());
+                var response = await _invoker.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
                 // Assert
                 Assert.NotSame(response.RequestMessage, httpRequestMessage);
                 Assert.Equal(response.RequestMessage?.RequestUri?.Host, httpRequestMessage.RequestUri?.Host);
@@ -768,7 +768,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests.Middleware
             mockHandler.SetHttpResponse(redirectResponse, new HttpResponseMessage(HttpStatusCode.OK));
 
             // Act
-            var response = await invoker.SendAsync(httpRequestMessage, CancellationToken.None);
+            var response = await invoker.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
 
             // Assert - ProxyAuthorization should be removed because internal.local is bypassed
             Assert.NotSame(response.RequestMessage, httpRequestMessage);
@@ -803,7 +803,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests.Middleware
             mockHandler.SetHttpResponse(redirectResponse, new HttpResponseMessage(HttpStatusCode.OK));
 
             // Act
-            var response = await invoker.SendAsync(httpRequestMessage, CancellationToken.None);
+            var response = await invoker.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
 
             // Assert - ProxyAuthorization should be kept because example.org requires proxy
             Assert.NotSame(response.RequestMessage, httpRequestMessage);
@@ -833,7 +833,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests.Middleware
             mockHandler.SetHttpResponse(redirectResponse, new HttpResponseMessage(HttpStatusCode.OK));
 
             // Act
-            var response = await invoker.SendAsync(httpRequestMessage, CancellationToken.None);
+            var response = await invoker.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
 
             // Assert - ProxyAuthorization should be removed when no proxy is configured
             Assert.NotSame(response.RequestMessage, httpRequestMessage);
@@ -855,7 +855,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests.Middleware
 
             // Act & Assert
             var exception = await Assert.ThrowsAsync<InvalidOperationException>(
-                () => this._invoker.SendAsync(httpRequestMessage, CancellationToken.None));
+                () => this._invoker.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken));
             Assert.Contains("Unable to perform redirect as Location Header is not set in response", exception.Message);
             Assert.Contains(statusCode.ToString(), exception.InnerException?.Message);
         }
@@ -875,7 +875,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests.Middleware
             this._testHttpMessageHandler.SetHttpResponse(redirectResponse);
 
             // Act
-            var response = await this._invoker.SendAsync(httpRequestMessage, CancellationToken.None);
+            var response = await this._invoker.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
 
             // Assert - response is returned as-is without following the redirect
             Assert.Equal(statusCode, response.StatusCode);
@@ -897,7 +897,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests.Middleware
             this._testHttpMessageHandler.SetHttpResponse(redirectResponse);
 
             // Act
-            var response = await this._invoker.SendAsync(httpRequestMessage, CancellationToken.None);
+            var response = await this._invoker.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
 
             // Assert - response is returned as-is without following the redirect
             Assert.Equal(statusCode, response.StatusCode);

--- a/tests/http/httpClient/Middleware/RetryHandlerTests.cs
+++ b/tests/http/httpClient/Middleware/RetryHandlerTests.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests.Middleware
             var retryResponse = new HttpResponseMessage(HttpStatusCode.OK);
             _testHttpMessageHandler.SetHttpResponse(retryResponse);
             // Act
-            var response = await _invoker.SendAsync(httpRequestMessage, new CancellationToken());
+            var response = await _invoker.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
             // Assert
             Assert.Same(response, retryResponse);
             Assert.NotNull(response.RequestMessage);
@@ -103,7 +103,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests.Middleware
             var response2 = new HttpResponseMessage(HttpStatusCode.OK);
             this._testHttpMessageHandler.SetHttpResponse(retryResponse, response2);
             // Act
-            var response = await _invoker.SendAsync(httpRequestMessage, new CancellationToken());
+            var response = await _invoker.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
             // Assert
             Assert.Same(response, response2);
             Assert.NotSame(response.RequestMessage, httpRequestMessage);
@@ -130,7 +130,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests.Middleware
             var response2 = new HttpResponseMessage(HttpStatusCode.OK);
             this._testHttpMessageHandler.SetHttpResponse(retryResponse, response2);
             // Act
-            var response = await _invoker.SendAsync(httpRequestMessage, new CancellationToken());
+            var response = await _invoker.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
             // Assert
             Assert.Same(response, response2);
             Assert.NotSame(response.RequestMessage, httpRequestMessage);
@@ -160,7 +160,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests.Middleware
             var response2 = new HttpResponseMessage(HttpStatusCode.OK);
             this._testHttpMessageHandler.SetHttpResponse(retryResponse, response2);
             // Act
-            var response = await _invoker.SendAsync(httpRequestMessage, new CancellationToken());
+            var response = await _invoker.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
             // Assert
             Assert.NotEqual(response, response2);
             Assert.Same(response, retryResponse);
@@ -187,7 +187,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests.Middleware
             var response2 = new HttpResponseMessage(HttpStatusCode.OK);
             this._testHttpMessageHandler.SetHttpResponse(retryResponse, response2);
             // Act
-            var response = await _invoker.SendAsync(httpRequestMessage, new CancellationToken());
+            var response = await _invoker.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
             // Assert
             Assert.NotEqual(response, response2);
             Assert.Same(response.RequestMessage, httpRequestMessage);
@@ -217,7 +217,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests.Middleware
             // Act
             try
             {
-                await invoker.SendAsync(httpRequestMessage, new CancellationToken());
+                await invoker.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
             }
             catch(Exception exception)
             {
@@ -299,7 +299,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests.Middleware
             _retryHandler.RetryOption.RetriesTimeLimit = TimeSpan.FromSeconds(10);
             this._testHttpMessageHandler.SetHttpResponse(retryResponse);
             // Act
-            var response = await _invoker.SendAsync(httpRequestMessage, new CancellationToken());
+            var response = await _invoker.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
             // Assert
             Assert.Same(response, retryResponse);
         }
@@ -320,7 +320,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests.Middleware
             var response2 = new HttpResponseMessage(HttpStatusCode.OK);
             this._testHttpMessageHandler.SetHttpResponse(retryResponse, response2);
             // Act
-            var response = await _invoker.SendAsync(httpRequestMessage, new CancellationToken());
+            var response = await _invoker.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
             // Assert
             Assert.Same(response, response2);
             Assert.NotNull(response.RequestMessage);
@@ -349,7 +349,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests.Middleware
             var response2 = new HttpResponseMessage(HttpStatusCode.OK);
             this._testHttpMessageHandler.SetHttpResponse(retryResponse, response2);
             // Act
-            var response = await _invoker.SendAsync(httpRequestMessage, new CancellationToken());
+            var response = await _invoker.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
             // Assert
             Assert.Same(response, response2);
             Assert.NotNull(response.RequestMessage);
@@ -367,7 +367,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests.Middleware
         public async Task ShouldRetryBasedOnCustomShouldRetryDelegate(int expectedMaxRetry, HttpStatusCode expectedStatusCode, bool isExceptionExpected)
         {
             // Arrange
-            var request = new HttpRequestMessage();
+            var request = new HttpRequestMessage(HttpMethod.Post, "http://example.org/foo");
             Queue<HttpResponseMessage> httpResponseQueue = new(new HttpResponseMessage[]
             {
                 new(HttpStatusCode.BadGateway) { RequestMessage = request },
@@ -379,7 +379,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests.Middleware
 
             var mockHttpMessageHandler = new Mock<HttpMessageHandler>(MockBehavior.Loose);
             mockHttpMessageHandler.Protected()
-                .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), It.IsAny<CancellationToken>())
+                .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
                 .Returns(() =>
                     {
                         HttpResponseMessage response;
@@ -410,7 +410,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests.Middleware
             // Act
             try
             {
-                var response = await httpMessageInvoker.SendAsync(request, new CancellationToken());
+                var response = await httpMessageInvoker.SendAsync(request, TestContext.Current.CancellationToken);
 
                 Assert.False(isExceptionExpected);
                 Assert.Equal(expectedStatusCode, response.StatusCode);
@@ -427,7 +427,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests.Middleware
             }
 
             // Assert
-            mockHttpMessageHandler.Protected().Verify<Task<HttpResponseMessage>>("SendAsync", Times.Exactly(1 + expectedMaxRetry), ItExpr.IsAny<HttpRequestMessage>(), It.IsAny<CancellationToken>());
+            mockHttpMessageHandler.Protected().Verify<Task<HttpResponseMessage>>("SendAsync", Times.Exactly(1 + expectedMaxRetry), ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>());
         }
 
         [Theory]
@@ -448,7 +448,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests.Middleware
             this._testHttpMessageHandler.SetHttpResponse(retryResponse, response2);
             _retryHandler.RetryOption.ShouldRetry = (_, _, _) => false;
             // Act
-            var response = await _invoker.SendAsync(httpRequestMessage, new CancellationToken());
+            var response = await _invoker.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
             // Assert
             Assert.NotEqual(response, response2);
             Assert.Same(response, retryResponse);
@@ -464,7 +464,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests.Middleware
             Message = message;
             await Task.Run(async () =>
             {
-                await RetryHandler.DelayAsync(response, count, delay, out _, new CancellationToken());
+                await RetryHandler.DelayAsync(response, count, delay, out _, TestContext.Current.CancellationToken);
                 Message += " Work " + count;
             });
         }

--- a/tests/http/httpClient/Middleware/TelemetryHandlerTests.cs
+++ b/tests/http/httpClient/Middleware/TelemetryHandlerTests.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests.Middleware
             Assert.Empty(requestMessage.Headers);
 
             // Act
-            var response = await _invoker.SendAsync(requestMessage, new CancellationToken());
+            var response = await _invoker.SendAsync(requestMessage, TestContext.Current.CancellationToken);
 
             // Assert the request stays the same
             Assert.Empty(response.RequestMessage?.Headers!);
@@ -75,7 +75,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests.Middleware
             Assert.Empty(requestMessage.Headers);
 
             // Act
-            var response = await _invoker.SendAsync(requestMessage, new CancellationToken());
+            var response = await _invoker.SendAsync(requestMessage, TestContext.Current.CancellationToken);
 
             // Assert the request was enriched as expected
             Assert.NotEmpty(response.RequestMessage?.Headers!);
@@ -116,7 +116,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests.Middleware
             Assert.Empty(requestMessage.Headers);
 
             // Act
-            var response = await invoker.SendAsync(requestMessage, new CancellationToken());
+            var response = await invoker.SendAsync(requestMessage, TestContext.Current.CancellationToken);
 
             // Assert the request was enriched as expected
             Assert.NotEmpty(response.RequestMessage?.Headers!);

--- a/tests/http/httpClient/Middleware/UserAgentHandlerTests.cs
+++ b/tests/http/httpClient/Middleware/UserAgentHandlerTests.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests.Middleware
             Assert.Empty(requestMessage.Headers);
 
             // Act
-            var response = await _invoker.SendAsync(requestMessage, new CancellationToken());
+            var response = await _invoker.SendAsync(requestMessage, TestContext.Current.CancellationToken);
 
             // Assert the request stays the same
             Assert.Empty(response.RequestMessage?.Headers!);
@@ -70,7 +70,7 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests.Middleware
             Assert.Empty(requestMessage.Headers);
 
             // Act
-            var response = await _invoker.SendAsync(requestMessage, new CancellationToken());
+            var response = await _invoker.SendAsync(requestMessage, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Single(response.RequestMessage?.Headers!);
@@ -98,8 +98,8 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests.Middleware
             Assert.Empty(requestMessage.Headers);
 
             // Act
-            var response = await _invoker.SendAsync(requestMessage, new CancellationToken());
-            response = await _invoker.SendAsync(requestMessage, new CancellationToken());
+            var response = await _invoker.SendAsync(requestMessage, TestContext.Current.CancellationToken);
+            response = await _invoker.SendAsync(requestMessage, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Single(response.RequestMessage?.Headers!);

--- a/tests/http/httpClient/Mocks/MockCompressedContent.cs
+++ b/tests/http/httpClient/Mocks/MockCompressedContent.cs
@@ -2,6 +2,7 @@
 using System.IO.Compression;
 using System.Net;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests.Mocks
@@ -19,8 +20,24 @@ namespace Microsoft.Kiota.Http.HttpClientLibrary.Tests.Mocks
 
         protected override async Task SerializeToStreamAsync(Stream stream, TransportContext? context)
         {
+            await SerializeToStreamAsync(stream, CancellationToken.None).ConfigureAwait(false);
+        }
+
+#if NET5_0_OR_GREATER
+        protected override async Task SerializeToStreamAsync(Stream stream, TransportContext? context, CancellationToken cancellationToken)
+        {
+            await SerializeToStreamAsync(stream, cancellationToken).ConfigureAwait(false);
+        }
+#endif
+
+        private async Task SerializeToStreamAsync(Stream stream, CancellationToken cancellationToken)
+        {
             Stream compressedStream = new GZipStream(stream, CompressionMode.Compress, true);
-            await _originalContent.CopyToAsync(compressedStream);
+#if NET5_0_OR_GREATER
+            await _originalContent.CopyToAsync(compressedStream, cancellationToken).ConfigureAwait(false);
+#else
+            await _originalContent.CopyToAsync(compressedStream).ConfigureAwait(false);
+#endif
             compressedStream.Dispose();
         }
 


### PR DESCRIPTION
- **fix: missing cancellation token forward to inner callees**
- **tests: use the cancellation token from the test context**
