### PR TITLE
Honor custom DateTimeOffset converters

### DIFF
--- a/src/serialization/json/JsonParseNode.cs
+++ b/src/serialization/json/JsonParseNode.cs
@@ -29,6 +29,7 @@ namespace Microsoft.Kiota.Serialization.Json
     /// </summary>
     public class JsonParseNode : IParseNode
     {
+        private static readonly JsonConverter DefaultDateTimeOffsetConverter = KiotaJsonSerializationContext.Default.DateTimeOffset.Converter;
         private readonly JsonElement _jsonNode;
         private readonly KiotaJsonSerializationContext _jsonSerializerContext;
 
@@ -338,7 +339,7 @@ namespace Microsoft.Kiota.Serialization.Json
             if(jsonElement.ValueKind != JsonValueKind.String)
                 return null;
 
-            if(TryGetUsingTypeInfo(jsonElement, _jsonSerializerContext.DateTimeOffset, out var convertedDateTimeOffset))
+            if(HasCustomDateTimeOffsetConverter() && TryGetUsingTypeInfo(jsonElement, _jsonSerializerContext.DateTimeOffset, out var convertedDateTimeOffset))
                 return convertedDateTimeOffset;
 
             if(jsonElement.TryGetDateTimeOffset(out var dateTimeOffset))
@@ -349,6 +350,9 @@ namespace Microsoft.Kiota.Serialization.Json
 
             return null;
         }
+
+        private bool HasCustomDateTimeOffsetConverter() =>
+            _jsonSerializerContext.DateTimeOffset is { Converter: var converter } && !ReferenceEquals(converter, DefaultDateTimeOffsetConverter);
 
         private TimeSpan? GetTimeSpanValue(JsonElement jsonElement)
         {

--- a/src/serialization/json/JsonParseNode.cs
+++ b/src/serialization/json/JsonParseNode.cs
@@ -338,11 +338,11 @@ namespace Microsoft.Kiota.Serialization.Json
             if(jsonElement.ValueKind != JsonValueKind.String)
                 return null;
 
-            if(jsonElement.TryGetDateTimeOffset(out var dateTimeOffset))
-                return dateTimeOffset;
-
             if(TryGetUsingTypeInfo(jsonElement, _jsonSerializerContext.DateTimeOffset, out var convertedDateTimeOffset))
                 return convertedDateTimeOffset;
+
+            if(jsonElement.TryGetDateTimeOffset(out var dateTimeOffset))
+                return dateTimeOffset;
 
             if(DateTimeOffset.TryParse(jsonElement.GetString(), CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var dto))
                 return dto;

--- a/tests/serialization/json/JsonParseNodeTests.cs
+++ b/tests/serialization/json/JsonParseNodeTests.cs
@@ -523,6 +523,48 @@ namespace Microsoft.Kiota.Serialization.Json.Tests
         }
 
         [Fact]
+        public void GetDateTimeOffsetValue_UsesCustomConverterForTimezoneLessValue()
+        {
+            // Arrange
+            var converter = new UtcDateTimeOffsetConverter();
+            var serializerOptions = new JsonSerializerOptions(JsonSerializerDefaults.General)
+            {
+                Converters = { converter }
+            };
+            var serializationContext = new KiotaJsonSerializationContext(serializerOptions);
+
+            using var jsonDocument = JsonDocument.Parse("\"2024-07-31T12:34:56\"");
+            var parseNode = new JsonParseNode(jsonDocument.RootElement, serializationContext);
+
+            // Act
+            var result = parseNode.GetDateTimeOffsetValue();
+
+            // Assert
+            Assert.True(converter.WasRead);
+            Assert.Equal(new DateTimeOffset(2024, 7, 31, 12, 34, 56, TimeSpan.Zero), result);
+        }
+
+        [Fact]
+        public void GetDateTimeOffsetValue_FallsBackWhenCustomConverterCannotParse()
+        {
+            // Arrange
+            var serializerOptions = new JsonSerializerOptions(JsonSerializerDefaults.General)
+            {
+                Converters = { new UtcDateTimeOffsetConverter() }
+            };
+            var serializationContext = new KiotaJsonSerializationContext(serializerOptions);
+
+            using var jsonDocument = JsonDocument.Parse("\"2024-07-31T12:34:56Z\"");
+            var parseNode = new JsonParseNode(jsonDocument.RootElement, serializationContext);
+
+            // Act
+            var result = parseNode.GetDateTimeOffsetValue();
+
+            // Assert
+            Assert.Equal(new DateTimeOffset(2024, 7, 31, 12, 34, 56, TimeSpan.Zero), result);
+        }
+
+        [Fact]
         public void GetDateTimeOffsetValue_ReturnCorrectDateTimeOffset()
         {
             // Arrange
@@ -1005,6 +1047,26 @@ namespace Microsoft.Kiota.Serialization.Json.Tests
             Assert.Equal(2, result.Length);
             Assert.Equal(new TimeSpan(1, 2, 3, 4), result[0]);
             Assert.Equal(new TimeSpan(2, 3, 4, 5), result[1]);
+        }
+
+        private sealed class UtcDateTimeOffsetConverter : JsonConverter<DateTimeOffset>
+        {
+            public bool WasRead { get; private set; }
+
+            public override DateTimeOffset Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+            {
+                WasRead = true;
+                var value = reader.GetString()!;
+                if(value.EndsWith("Z", StringComparison.Ordinal))
+                    throw new JsonException();
+
+                return new DateTimeOffset(DateTime.SpecifyKind(
+                    DateTime.ParseExact(value, "yyyy-MM-ddTHH:mm:ss", CultureInfo.InvariantCulture),
+                    DateTimeKind.Utc));
+            }
+
+            public override void Write(Utf8JsonWriter writer, DateTimeOffset value, JsonSerializerOptions options)
+                => throw new NotImplementedException();
         }
     }
 }

--- a/tests/serialization/json/JsonParseNodeTests.cs
+++ b/tests/serialization/json/JsonParseNodeTests.cs
@@ -548,9 +548,10 @@ namespace Microsoft.Kiota.Serialization.Json.Tests
         public void GetDateTimeOffsetValue_FallsBackWhenCustomConverterCannotParse()
         {
             // Arrange
+            var converter = new UtcDateTimeOffsetConverter();
             var serializerOptions = new JsonSerializerOptions(JsonSerializerDefaults.General)
             {
-                Converters = { new UtcDateTimeOffsetConverter() }
+                Converters = { converter }
             };
             var serializationContext = new KiotaJsonSerializationContext(serializerOptions);
 
@@ -561,6 +562,7 @@ namespace Microsoft.Kiota.Serialization.Json.Tests
             var result = parseNode.GetDateTimeOffsetValue();
 
             // Assert
+            Assert.True(converter.WasRead);
             Assert.Equal(new DateTimeOffset(2024, 7, 31, 12, 34, 56, TimeSpan.Zero), result);
         }
 


### PR DESCRIPTION
## Summary

- Try custom `DateTimeOffset` converters before built-in parsing.
- Keep the current fallback when a converter cannot parse a value.
- Add regression tests for both paths.

Fixes #692

## Validation

- JSON serialization tests: 144 passed on .NET 8.
- JSON serialization tests: 144 passed on .NET 10.
- JSON serialization tests: 144 passed on .NET Framework.
- JSON serialization test project build passed with no warnings or errors.
- Formatting check passed.

## AI assistance

GitHub Copilot helped implement and validate this change.