### PR TITLE
fix(serialization-json): honor custom TimeSpan converters

### DIFF
--- a/src/serialization/json/JsonParseNode.cs
+++ b/src/serialization/json/JsonParseNode.cs
@@ -355,15 +355,14 @@ namespace Microsoft.Kiota.Serialization.Json
             if(jsonElement.ValueKind != JsonValueKind.String)
                 return null;
 
-            var jsonString = jsonElement.GetString();
-            if(string.IsNullOrEmpty(jsonString))
+            if(jsonElement.ValueEquals(ReadOnlySpan<byte>.Empty))
                 return null;
 
             if(TryGetUsingTypeInfo(jsonElement, _jsonSerializerContext.TimeSpan, out var convertedTimeSpan))
                 return convertedTimeSpan;
 
             // Parse an ISO8601 duration.http://en.wikipedia.org/wiki/ISO_8601#Durations to a TimeSpan
-            return XmlConvert.ToTimeSpan(jsonString);
+            return XmlConvert.ToTimeSpan(jsonElement.GetString()!);
         }
 
         private Date? GetDateValue(JsonElement jsonElement)

--- a/src/serialization/json/JsonParseNode.cs
+++ b/src/serialization/json/JsonParseNode.cs
@@ -350,11 +350,17 @@ namespace Microsoft.Kiota.Serialization.Json
             return null;
         }
 
-        private static TimeSpan? GetTimeSpanValue(JsonElement jsonElement)
+        private TimeSpan? GetTimeSpanValue(JsonElement jsonElement)
         {
+            if(jsonElement.ValueKind != JsonValueKind.String)
+                return null;
+
             var jsonString = jsonElement.GetString();
             if(string.IsNullOrEmpty(jsonString))
                 return null;
+
+            if(TryGetUsingTypeInfo(jsonElement, _jsonSerializerContext.TimeSpan, out var convertedTimeSpan))
+                return convertedTimeSpan;
 
             // Parse an ISO8601 duration.http://en.wikipedia.org/wiki/ISO_8601#Durations to a TimeSpan
             return XmlConvert.ToTimeSpan(jsonString);

--- a/tests/serialization/json/Converters/JsonTimeSpanConverter.cs
+++ b/tests/serialization/json/Converters/JsonTimeSpanConverter.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Microsoft.Kiota.Serialization.Json.Tests.Converters;
+
+/// <summary>
+/// Converts a TimeSpan object or value to/from JSON.
+/// </summary>
+public class JsonTimeSpanConverter : JsonConverter<TimeSpan>
+{
+    private const string Format = @"d\|hh\|mm\|ss";
+
+    /// <inheritdoc />
+    public override TimeSpan Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        => reader.TokenType == JsonTokenType.Null
+            ? TimeSpan.Zero
+            : ReadInternal(ref reader);
+
+    /// <inheritdoc />
+    public override void Write(Utf8JsonWriter writer, TimeSpan value, JsonSerializerOptions options)
+        => WriteInternal(writer, value);
+
+    private static TimeSpan ReadInternal(ref Utf8JsonReader reader)
+        => TimeSpan.ParseExact(reader.GetString()!, Format, CultureInfo.InvariantCulture);
+
+    private static void WriteInternal(Utf8JsonWriter writer, TimeSpan value)
+        => writer.WriteStringValue(value.ToString(Format, CultureInfo.InvariantCulture));
+}

--- a/tests/serialization/json/JsonParseNodeTests.cs
+++ b/tests/serialization/json/JsonParseNodeTests.cs
@@ -563,6 +563,26 @@ namespace Microsoft.Kiota.Serialization.Json.Tests
             Assert.Equal(new TimeSpan(1, 2, 3, 4), result);
         }
 
+        [Fact]
+        public void GetTimeSpanValue_ReturnsNullForEmptyStringWhenCustomConverterIsUsed()
+        {
+            // Arrange
+            var serializerOptions = new JsonSerializerOptions(JsonSerializerDefaults.General)
+            {
+                Converters = { new JsonTimeSpanConverter() }
+            };
+            var serializationContext = new KiotaJsonSerializationContext(serializerOptions);
+
+            using var jsonDocument = JsonDocument.Parse("\"\"");
+            var parseNode = new JsonParseNode(jsonDocument.RootElement, serializationContext);
+
+            // Act
+            var result = parseNode.GetTimeSpanValue();
+
+            // Assert
+            Assert.Null(result);
+        }
+
         [Theory]
         [InlineData("42", 42)]
         [InlineData("\"42\"", null)]

--- a/tests/serialization/json/JsonParseNodeTests.cs
+++ b/tests/serialization/json/JsonParseNodeTests.cs
@@ -542,6 +542,27 @@ namespace Microsoft.Kiota.Serialization.Json.Tests
             Assert.Equal(56, result.Value.Second);
         }
 
+        [Fact]
+        public void GetTimeSpanValue_ReturnsTimeSpanWhenCustomConverterIsUsed()
+        {
+            // Arrange
+            var serializerOptions = new JsonSerializerOptions(JsonSerializerDefaults.General)
+            {
+                Converters = { new JsonTimeSpanConverter() }
+            };
+            var serializationContext = new KiotaJsonSerializationContext(serializerOptions);
+
+            using var jsonDocument = JsonDocument.Parse("\"1|02|03|04\"");
+            var parseNode = new JsonParseNode(jsonDocument.RootElement, serializationContext);
+
+            // Act
+            var result = parseNode.GetTimeSpanValue();
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal(new TimeSpan(1, 2, 3, 4), result);
+        }
+
         [Theory]
         [InlineData("42", 42)]
         [InlineData("\"42\"", null)]
@@ -942,6 +963,28 @@ namespace Microsoft.Kiota.Serialization.Json.Tests
             Assert.Equal((sbyte)-1, result[0]);
             Assert.Equal((sbyte)0, result[1]);
             Assert.Equal((sbyte)1, result[2]);
+        }
+
+        [Fact]
+        public void GetCollectionOfPrimitiveValues_ReturnsTimeSpanCollectionWhenCustomConverterIsUsed()
+        {
+            // Arrange
+            var serializerOptions = new JsonSerializerOptions(JsonSerializerDefaults.General)
+            {
+                Converters = { new JsonTimeSpanConverter() }
+            };
+            var serializationContext = new KiotaJsonSerializationContext(serializerOptions);
+
+            using var jsonDocument = JsonDocument.Parse("[\"1|02|03|04\", \"2|03|04|05\"]");
+            var parseNode = new JsonParseNode(jsonDocument.RootElement, serializationContext);
+
+            // Act
+            var result = parseNode.GetCollectionOfPrimitiveValues<TimeSpan?>().ToArray();
+
+            // Assert
+            Assert.Equal(2, result.Length);
+            Assert.Equal(new TimeSpan(1, 2, 3, 4), result[0]);
+            Assert.Equal(new TimeSpan(2, 3, 4, 5), result[1]);
         }
     }
 }


### PR DESCRIPTION
## Summary
- add regression coverage for custom `JsonConverter<TimeSpan>` parsing
- use `KiotaJsonSerializationContext.TimeSpan` during JSON TimeSpan parsing before the ISO 8601 fallback
- cover both single TimeSpan values and primitive TimeSpan collections

Fixes #792